### PR TITLE
[Refactor] Pass experiment object to algorithm

### DIFF
--- a/benchmarl/algorithms/iddpg.py
+++ b/benchmarl/algorithms/iddpg.py
@@ -101,6 +101,7 @@ class Iddpg(Algorithm):
                 centralised=False,
                 share_params=self.experiment_config.share_policy_params,
                 device=self.device,
+                experiment=self.experiment,
             )
 
             policy = ProbabilisticActor(
@@ -217,6 +218,7 @@ class Iddpg(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                experiment=self.experiment,
             )
         )
 

--- a/benchmarl/algorithms/iddpg.py
+++ b/benchmarl/algorithms/iddpg.py
@@ -101,6 +101,7 @@ class Iddpg(Algorithm):
                 centralised=False,
                 share_params=self.experiment_config.share_policy_params,
                 device=self.device,
+                action_spec=self.action_spec,
             )
 
             policy = ProbabilisticActor(
@@ -217,6 +218,7 @@ class Iddpg(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                action_spec=self.action_spec,
             )
         )
 

--- a/benchmarl/algorithms/iddpg.py
+++ b/benchmarl/algorithms/iddpg.py
@@ -101,7 +101,6 @@ class Iddpg(Algorithm):
                 centralised=False,
                 share_params=self.experiment_config.share_policy_params,
                 device=self.device,
-                experiment=self.experiment,
             )
 
             policy = ProbabilisticActor(
@@ -218,7 +217,6 @@ class Iddpg(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
-                experiment=self.experiment,
             )
         )
 

--- a/benchmarl/algorithms/ippo.py
+++ b/benchmarl/algorithms/ippo.py
@@ -30,6 +30,7 @@ class Ippo(Algorithm):
         critic_coef: float,
         loss_critic_type: str,
         lmbda: float,
+        scale_mapping: str,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -40,6 +41,7 @@ class Ippo(Algorithm):
         self.critic_coef = critic_coef
         self.loss_critic_type = loss_critic_type
         self.lmbda = lmbda
+        self.scale_mapping = scale_mapping
 
     #############################
     # Overridden abstract methods
@@ -122,12 +124,11 @@ class Ippo(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
-            experiment=self.experiment,
         )
 
         if continuous:
             extractor_module = TensorDictModule(
-                NormalParamExtractor(),
+                NormalParamExtractor(scale_mapping=self.scale_mapping),
                 in_keys=[(group, "logits")],
                 out_keys=[(group, "loc"), (group, "scale")],
             )
@@ -260,7 +261,6 @@ class Ippo(Algorithm):
             agent_group=group,
             share_params=self.share_param_critic,
             device=self.device,
-            experiment=self.experiment,
         )
 
         return value_module
@@ -274,6 +274,7 @@ class IppoConfig(AlgorithmConfig):
     critic_coef: float = MISSING
     loss_critic_type: str = MISSING
     lmbda: float = MISSING
+    scale_mapping: str = MISSING
 
     @staticmethod
     def associated_class() -> Type[Algorithm]:

--- a/benchmarl/algorithms/ippo.py
+++ b/benchmarl/algorithms/ippo.py
@@ -48,7 +48,6 @@ class Ippo(Algorithm):
     def _get_loss(
         self, group: str, policy_for_loss: TensorDictModule, continuous: bool
     ) -> Tuple[LossModule, bool]:
-
         # Loss
         loss_module = ClipPPOLoss(
             actor=policy_for_loss,
@@ -83,7 +82,6 @@ class Ippo(Algorithm):
     def _get_policy_for_loss(
         self, group: str, model_config: ModelConfig, continuous: bool
     ) -> TensorDictModule:
-
         n_agents = len(self.group_map[group])
         if continuous:
             logits_shape = list(self.action_spec[group, "action"].shape)
@@ -124,6 +122,7 @@ class Ippo(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            experiment=self.experiment,
         )
 
         if continuous:
@@ -261,6 +260,7 @@ class Ippo(Algorithm):
             agent_group=group,
             share_params=self.share_param_critic,
             device=self.device,
+            experiment=self.experiment,
         )
 
         return value_module
@@ -268,7 +268,6 @@ class Ippo(Algorithm):
 
 @dataclass
 class IppoConfig(AlgorithmConfig):
-
     share_param_critic: bool = MISSING
     clip_epsilon: float = MISSING
     entropy_coef: float = MISSING

--- a/benchmarl/algorithms/ippo.py
+++ b/benchmarl/algorithms/ippo.py
@@ -124,6 +124,7 @@ class Ippo(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            action_spec=self.action_spec,
         )
 
         if continuous:
@@ -261,6 +262,7 @@ class Ippo(Algorithm):
             agent_group=group,
             share_params=self.share_param_critic,
             device=self.device,
+            action_spec=self.action_spec,
         )
 
         return value_module

--- a/benchmarl/algorithms/iql.py
+++ b/benchmarl/algorithms/iql.py
@@ -98,7 +98,6 @@ class Iql(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
-            experiment=self.experiment,
         )
         if self.action_mask_spec is not None:
             action_mask_key = (group, "action_mask")

--- a/benchmarl/algorithms/iql.py
+++ b/benchmarl/algorithms/iql.py
@@ -98,6 +98,7 @@ class Iql(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            action_spec=self.action_spec,
         )
         if self.action_mask_spec is not None:
             action_mask_key = (group, "action_mask")

--- a/benchmarl/algorithms/iql.py
+++ b/benchmarl/algorithms/iql.py
@@ -62,7 +62,6 @@ class Iql(Algorithm):
     def _get_policy_for_loss(
         self, group: str, model_config: ModelConfig, continuous: bool
     ) -> TensorDictModule:
-
         n_agents = len(self.group_map[group])
         logits_shape = [
             *self.action_spec[group, "action"].shape,
@@ -99,6 +98,7 @@ class Iql(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            experiment=self.experiment,
         )
         if self.action_mask_spec is not None:
             action_mask_key = (group, "action_mask")
@@ -175,7 +175,6 @@ class Iql(Algorithm):
 
 @dataclass
 class IqlConfig(AlgorithmConfig):
-
     delay_value: bool = MISSING
     loss_function: str = MISSING
 

--- a/benchmarl/algorithms/isac.py
+++ b/benchmarl/algorithms/isac.py
@@ -38,6 +38,7 @@ class Isac(Algorithm):
         min_alpha: Optional[float],
         max_alpha: Optional[float],
         fixed_alpha: bool,
+        scale_mapping: str,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -52,6 +53,7 @@ class Isac(Algorithm):
         self.min_alpha = min_alpha
         self.max_alpha = max_alpha
         self.fixed_alpha = fixed_alpha
+        self.scale_mapping = scale_mapping
 
     #############################
     # Overridden abstract methods
@@ -166,12 +168,11 @@ class Isac(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
-            experiment=self.experiment,
         )
 
         if continuous:
             extractor_module = TensorDictModule(
-                NormalParamExtractor(),
+                NormalParamExtractor(scale_mapping=self.scale_mapping),
                 in_keys=[(group, "logits")],
                 out_keys=[(group, "loc"), (group, "scale")],
             )
@@ -291,7 +292,6 @@ class Isac(Algorithm):
             agent_group=group,
             share_params=self.share_param_critic,
             device=self.device,
-            experiment=self.experiment,
         )
 
         return value_module
@@ -347,7 +347,6 @@ class Isac(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
-                experiment=self.experiment,
             )
         )
 
@@ -368,6 +367,7 @@ class IsacConfig(AlgorithmConfig):
     min_alpha: Optional[float] = MISSING
     max_alpha: Optional[float] = MISSING
     fixed_alpha: bool = MISSING
+    scale_mapping: str = MISSING
 
     @staticmethod
     def associated_class() -> Type[Algorithm]:

--- a/benchmarl/algorithms/isac.py
+++ b/benchmarl/algorithms/isac.py
@@ -126,7 +126,6 @@ class Isac(Algorithm):
     def _get_policy_for_loss(
         self, group: str, model_config: ModelConfig, continuous: bool
     ) -> TensorDictModule:
-
         n_agents = len(self.group_map[group])
         if continuous:
             logits_shape = list(self.action_spec[group, "action"].shape)
@@ -167,6 +166,7 @@ class Isac(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            experiment=self.experiment,
         )
 
         if continuous:
@@ -291,6 +291,7 @@ class Isac(Algorithm):
             agent_group=group,
             share_params=self.share_param_critic,
             device=self.device,
+            experiment=self.experiment,
         )
 
         return value_module
@@ -346,6 +347,7 @@ class Isac(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                experiment=self.experiment,
             )
         )
 
@@ -354,7 +356,6 @@ class Isac(Algorithm):
 
 @dataclass
 class IsacConfig(AlgorithmConfig):
-
     share_param_critic: bool = MISSING
 
     num_qvalue_nets: int = MISSING

--- a/benchmarl/algorithms/isac.py
+++ b/benchmarl/algorithms/isac.py
@@ -168,6 +168,7 @@ class Isac(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            action_spec=self.action_spec,
         )
 
         if continuous:
@@ -292,6 +293,7 @@ class Isac(Algorithm):
             agent_group=group,
             share_params=self.share_param_critic,
             device=self.device,
+            action_spec=self.action_spec,
         )
 
         return value_module
@@ -347,6 +349,7 @@ class Isac(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                action_spec=self.action_spec,
             )
         )
 

--- a/benchmarl/algorithms/maddpg.py
+++ b/benchmarl/algorithms/maddpg.py
@@ -102,6 +102,7 @@ class Maddpg(Algorithm):
                 centralised=False,
                 share_params=self.experiment_config.share_policy_params,
                 device=self.device,
+                action_spec=self.action_spec,
             )
 
             policy = ProbabilisticActor(
@@ -221,6 +222,7 @@ class Maddpg(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
+                    action_spec=self.action_spec,
                 )
             )
 
@@ -261,6 +263,7 @@ class Maddpg(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
+                    action_spec=self.action_spec,
                 )
             )
 

--- a/benchmarl/algorithms/maddpg.py
+++ b/benchmarl/algorithms/maddpg.py
@@ -102,7 +102,6 @@ class Maddpg(Algorithm):
                 centralised=False,
                 share_params=self.experiment_config.share_policy_params,
                 device=self.device,
-                experiment=self.experiment,
             )
 
             policy = ProbabilisticActor(
@@ -222,7 +221,6 @@ class Maddpg(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
-                    experiment=self.experiment,
                 )
             )
 
@@ -263,7 +261,6 @@ class Maddpg(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
-                    experiment=self.experiment,
                 )
             )
 

--- a/benchmarl/algorithms/maddpg.py
+++ b/benchmarl/algorithms/maddpg.py
@@ -62,7 +62,6 @@ class Maddpg(Algorithm):
             )
 
     def _get_parameters(self, group: str, loss: LossModule) -> Dict[str, Iterable]:
-
         return {
             "loss_actor": list(loss.actor_network_params.flatten_keys().values()),
             "loss_value": list(loss.value_network_params.flatten_keys().values()),
@@ -103,6 +102,7 @@ class Maddpg(Algorithm):
                 centralised=False,
                 share_params=self.experiment_config.share_policy_params,
                 device=self.device,
+                experiment=self.experiment,
             )
 
             policy = ProbabilisticActor(
@@ -222,11 +222,11 @@ class Maddpg(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
+                    experiment=self.experiment,
                 )
             )
 
         else:
-
             modules.append(
                 TensorDictModule(
                     lambda obs, action: torch.cat([obs, action], dim=-1),
@@ -263,6 +263,7 @@ class Maddpg(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
+                    experiment=self.experiment,
                 )
             )
 
@@ -282,7 +283,6 @@ class Maddpg(Algorithm):
 
 @dataclass
 class MaddpgConfig(AlgorithmConfig):
-
     share_param_critic: bool = MISSING
 
     loss_function: str = MISSING

--- a/benchmarl/algorithms/mappo.py
+++ b/benchmarl/algorithms/mappo.py
@@ -123,6 +123,7 @@ class Mappo(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            experiment=self.experiment,
         )
 
         if continuous:
@@ -258,6 +259,7 @@ class Mappo(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                experiment=self.experiment,
             )
 
         else:
@@ -282,6 +284,7 @@ class Mappo(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                experiment=self.experiment,
             )
         if self.share_param_critic:
             expand_module = TensorDictModule(

--- a/benchmarl/algorithms/mappo.py
+++ b/benchmarl/algorithms/mappo.py
@@ -123,6 +123,7 @@ class Mappo(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            action_spec=self.action_spec,
         )
 
         if continuous:
@@ -258,6 +259,7 @@ class Mappo(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                action_spec=self.action_spec,
             )
 
         else:
@@ -282,6 +284,7 @@ class Mappo(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                action_spec=self.action_spec,
             )
         if self.share_param_critic:
             expand_module = TensorDictModule(

--- a/benchmarl/algorithms/mappo.py
+++ b/benchmarl/algorithms/mappo.py
@@ -7,14 +7,6 @@
 #  This source code is licensed under the license found in the
 #  LICENSE file in the root directory of this source tree.
 #
-#
-#  This source code is licensed under the license found in the
-#  LICENSE file in the root directory of this source tree.
-#
-#
-#  This source code is licensed under the license found in the
-#  LICENSE file in the root directory of this source tree.
-#
 
 from dataclasses import dataclass, MISSING
 from typing import Dict, Iterable, Tuple, Type

--- a/benchmarl/algorithms/mappo.py
+++ b/benchmarl/algorithms/mappo.py
@@ -3,10 +3,6 @@
 #  This source code is licensed under the license found in the
 #  LICENSE file in the root directory of this source tree.
 #
-#
-#  This source code is licensed under the license found in the
-#  LICENSE file in the root directory of this source tree.
-#
 
 from dataclasses import dataclass, MISSING
 from typing import Dict, Iterable, Tuple, Type

--- a/benchmarl/algorithms/mappo.py
+++ b/benchmarl/algorithms/mappo.py
@@ -3,6 +3,18 @@
 #  This source code is licensed under the license found in the
 #  LICENSE file in the root directory of this source tree.
 #
+#
+#  This source code is licensed under the license found in the
+#  LICENSE file in the root directory of this source tree.
+#
+#
+#  This source code is licensed under the license found in the
+#  LICENSE file in the root directory of this source tree.
+#
+#
+#  This source code is licensed under the license found in the
+#  LICENSE file in the root directory of this source tree.
+#
 
 from dataclasses import dataclass, MISSING
 from typing import Dict, Iterable, Tuple, Type
@@ -29,6 +41,7 @@ class Mappo(Algorithm):
         critic_coef: float,
         loss_critic_type: str,
         lmbda: float,
+        scale_mapping: str,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -39,6 +52,7 @@ class Mappo(Algorithm):
         self.critic_coef = critic_coef
         self.loss_critic_type = loss_critic_type
         self.lmbda = lmbda
+        self.scale_mapping = scale_mapping
 
     #############################
     # Overridden abstract methods
@@ -47,7 +61,6 @@ class Mappo(Algorithm):
     def _get_loss(
         self, group: str, policy_for_loss: TensorDictModule, continuous: bool
     ) -> Tuple[LossModule, bool]:
-
         # Loss
         loss_module = ClipPPOLoss(
             actor=policy_for_loss,
@@ -74,7 +87,6 @@ class Mappo(Algorithm):
         return loss_module, False
 
     def _get_parameters(self, group: str, loss: ClipPPOLoss) -> Dict[str, Iterable]:
-
         return {
             "loss_objective": list(loss.actor_params.flatten_keys().values()),
             "loss_critic": list(loss.critic_params.flatten_keys().values()),
@@ -83,7 +95,6 @@ class Mappo(Algorithm):
     def _get_policy_for_loss(
         self, group: str, model_config: ModelConfig, continuous: bool
     ) -> TensorDictModule:
-
         n_agents = len(self.group_map[group])
         if continuous:
             logits_shape = list(self.action_spec[group, "action"].shape)
@@ -128,7 +139,7 @@ class Mappo(Algorithm):
 
         if continuous:
             extractor_module = TensorDictModule(
-                NormalParamExtractor(),
+                NormalParamExtractor(scale_mapping=self.scale_mapping),
                 in_keys=[(group, "logits")],
                 out_keys=[(group, "loc"), (group, "scale")],
             )
@@ -299,13 +310,13 @@ class Mappo(Algorithm):
 
 @dataclass
 class MappoConfig(AlgorithmConfig):
-
     share_param_critic: bool = MISSING
     clip_epsilon: float = MISSING
     entropy_coef: float = MISSING
     critic_coef: float = MISSING
     loss_critic_type: str = MISSING
     lmbda: float = MISSING
+    scale_mapping: str = MISSING
 
     @staticmethod
     def associated_class() -> Type[Algorithm]:

--- a/benchmarl/algorithms/mappo.py
+++ b/benchmarl/algorithms/mappo.py
@@ -123,7 +123,6 @@ class Mappo(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
-            experiment=self.experiment,
         )
 
         if continuous:
@@ -259,7 +258,6 @@ class Mappo(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
-                experiment=self.experiment,
             )
 
         else:
@@ -284,7 +282,6 @@ class Mappo(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
-                experiment=self.experiment,
             )
         if self.share_param_critic:
             expand_module = TensorDictModule(

--- a/benchmarl/algorithms/masac.py
+++ b/benchmarl/algorithms/masac.py
@@ -121,7 +121,6 @@ class Masac(Algorithm):
     def _get_policy_for_loss(
         self, group: str, model_config: ModelConfig, continuous: bool
     ) -> TensorDictModule:
-
         n_agents = len(self.group_map[group])
         if continuous:
             logits_shape = list(self.action_spec[group, "action"].shape)
@@ -162,6 +161,7 @@ class Masac(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            experiment=self.experiment,
         )
 
         if continuous:
@@ -279,6 +279,7 @@ class Masac(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                experiment=self.experiment,
             )
 
         else:
@@ -303,6 +304,7 @@ class Masac(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                experiment=self.experiment,
             )
         if self.share_param_critic:
             expand_module = TensorDictModule(
@@ -369,11 +371,11 @@ class Masac(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
+                    experiment=self.experiment,
                 )
             )
 
         else:
-
             modules.append(
                 TensorDictModule(
                     lambda obs, action: torch.cat([obs, action], dim=-1),
@@ -410,6 +412,7 @@ class Masac(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
+                    experiment=self.experiment,
                 )
             )
 
@@ -429,7 +432,6 @@ class Masac(Algorithm):
 
 @dataclass
 class MasacConfig(AlgorithmConfig):
-
     share_param_critic: bool = MISSING
 
     num_qvalue_nets: int = MISSING

--- a/benchmarl/algorithms/masac.py
+++ b/benchmarl/algorithms/masac.py
@@ -32,6 +32,7 @@ class Masac(Algorithm):
         min_alpha: Optional[float],
         max_alpha: Optional[float],
         fixed_alpha: bool,
+        scale_mapping: str,
         **kwargs
     ):
         super().__init__(**kwargs)
@@ -46,6 +47,7 @@ class Masac(Algorithm):
         self.min_alpha = min_alpha
         self.max_alpha = max_alpha
         self.fixed_alpha = fixed_alpha
+        self.scale_mapping = scale_mapping
 
     #############################
     # Overridden abstract methods
@@ -161,12 +163,11 @@ class Masac(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
-            experiment=self.experiment,
         )
 
         if continuous:
             extractor_module = TensorDictModule(
-                NormalParamExtractor(),
+                NormalParamExtractor(scale_mapping=self.scale_mapping),
                 in_keys=[(group, "logits")],
                 out_keys=[(group, "loc"), (group, "scale")],
             )
@@ -279,7 +280,6 @@ class Masac(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
-                experiment=self.experiment,
             )
 
         else:
@@ -304,7 +304,6 @@ class Masac(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
-                experiment=self.experiment,
             )
         if self.share_param_critic:
             expand_module = TensorDictModule(
@@ -371,7 +370,6 @@ class Masac(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
-                    experiment=self.experiment,
                 )
             )
 
@@ -412,7 +410,6 @@ class Masac(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
-                    experiment=self.experiment,
                 )
             )
 
@@ -444,6 +441,7 @@ class MasacConfig(AlgorithmConfig):
     min_alpha: Optional[float] = MISSING
     max_alpha: Optional[float] = MISSING
     fixed_alpha: bool = MISSING
+    scale_mapping: str = MISSING
 
     @staticmethod
     def associated_class() -> Type[Algorithm]:

--- a/benchmarl/algorithms/masac.py
+++ b/benchmarl/algorithms/masac.py
@@ -163,6 +163,7 @@ class Masac(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            action_spec=self.action_spec,
         )
 
         if continuous:
@@ -280,6 +281,7 @@ class Masac(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                action_spec=self.action_spec,
             )
 
         else:
@@ -304,6 +306,7 @@ class Masac(Algorithm):
                 agent_group=group,
                 share_params=self.share_param_critic,
                 device=self.device,
+                action_spec=self.action_spec,
             )
         if self.share_param_critic:
             expand_module = TensorDictModule(
@@ -370,6 +373,7 @@ class Masac(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
+                    action_spec=self.action_spec,
                 )
             )
 
@@ -410,6 +414,7 @@ class Masac(Algorithm):
                     agent_group=group,
                     share_params=self.share_param_critic,
                     device=self.device,
+                    action_spec=self.action_spec,
                 )
             )
 

--- a/benchmarl/algorithms/qmix.py
+++ b/benchmarl/algorithms/qmix.py
@@ -103,6 +103,7 @@ class Qmix(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            action_spec=self.action_spec,
         )
         if self.action_mask_spec is not None:
             action_mask_key = (group, "action_mask")

--- a/benchmarl/algorithms/qmix.py
+++ b/benchmarl/algorithms/qmix.py
@@ -103,7 +103,6 @@ class Qmix(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
-            experiment=self.experiment,
         )
         if self.action_mask_spec is not None:
             action_mask_key = (group, "action_mask")

--- a/benchmarl/algorithms/qmix.py
+++ b/benchmarl/algorithms/qmix.py
@@ -67,7 +67,6 @@ class Qmix(Algorithm):
     def _get_policy_for_loss(
         self, group: str, model_config: ModelConfig, continuous: bool
     ) -> TensorDictModule:
-
         n_agents = len(self.group_map[group])
         logits_shape = [
             *self.action_spec[group, "action"].shape,
@@ -104,6 +103,7 @@ class Qmix(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            experiment=self.experiment,
         )
         if self.action_mask_spec is not None:
             action_mask_key = (group, "action_mask")
@@ -175,7 +175,6 @@ class Qmix(Algorithm):
     #####################
 
     def get_mixer(self, group: str) -> TensorDictModule:
-
         n_agents = len(self.group_map[group])
 
         if self.state_spec is not None:
@@ -201,7 +200,6 @@ class Qmix(Algorithm):
 
 @dataclass
 class QmixConfig(AlgorithmConfig):
-
     mixing_embed_dim: int = MISSING
     delay_value: bool = MISSING
     loss_function: str = MISSING

--- a/benchmarl/algorithms/vdn.py
+++ b/benchmarl/algorithms/vdn.py
@@ -102,7 +102,6 @@ class Vdn(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
-            experiment=self.experiment,
         )
         if self.action_mask_spec is not None:
             action_mask_key = (group, "action_mask")

--- a/benchmarl/algorithms/vdn.py
+++ b/benchmarl/algorithms/vdn.py
@@ -59,7 +59,6 @@ class Vdn(Algorithm):
             return loss_module, True
 
     def _get_parameters(self, group: str, loss: LossModule) -> Dict[str, Iterable]:
-
         return {
             "loss": loss.parameters(),
         }
@@ -67,7 +66,6 @@ class Vdn(Algorithm):
     def _get_policy_for_loss(
         self, group: str, model_config: ModelConfig, continuous: bool
     ) -> TensorDictModule:
-
         n_agents = len(self.group_map[group])
         logits_shape = [
             *self.action_spec[group, "action"].shape,
@@ -104,6 +102,7 @@ class Vdn(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            experiment=self.experiment,
         )
         if self.action_mask_spec is not None:
             action_mask_key = (group, "action_mask")
@@ -175,7 +174,6 @@ class Vdn(Algorithm):
     #####################
 
     def get_mixer(self, group: str) -> TensorDictModule:
-
         n_agents = len(self.group_map[group])
         mixer = TensorDictModule(
             module=VDNMixer(
@@ -191,7 +189,6 @@ class Vdn(Algorithm):
 
 @dataclass
 class VdnConfig(AlgorithmConfig):
-
     delay_value: bool = MISSING
     loss_function: str = MISSING
 

--- a/benchmarl/algorithms/vdn.py
+++ b/benchmarl/algorithms/vdn.py
@@ -102,6 +102,7 @@ class Vdn(Algorithm):
             centralised=False,
             share_params=self.experiment_config.share_policy_params,
             device=self.device,
+            action_spec=self.action_spec,
         )
         if self.action_mask_spec is not None:
             action_mask_key = (group, "action_mask")

--- a/benchmarl/conf/algorithm/ippo.yaml
+++ b/benchmarl/conf/algorithm/ippo.yaml
@@ -9,3 +9,4 @@ entropy_coef: 0.0
 critic_coef: 1.0
 loss_critic_type: "l2"
 lmbda: 0.9
+scale_mapping: "biased_softplus_1.0"

--- a/benchmarl/conf/algorithm/isac.yaml
+++ b/benchmarl/conf/algorithm/isac.yaml
@@ -15,3 +15,4 @@ alpha_init: 1.0
 min_alpha: null
 max_alpha: null
 fixed_alpha: False
+scale_mapping: "biased_softplus_1.0"

--- a/benchmarl/conf/algorithm/mappo.yaml
+++ b/benchmarl/conf/algorithm/mappo.yaml
@@ -10,3 +10,4 @@ entropy_coef: 0.0
 critic_coef: 1.0
 loss_critic_type: "l2"
 lmbda: 0.9
+scale_mapping: "biased_softplus_1.0"

--- a/benchmarl/conf/algorithm/masac.yaml
+++ b/benchmarl/conf/algorithm/masac.yaml
@@ -16,3 +16,4 @@ alpha_init: 1.0
 min_alpha: null
 max_alpha: null
 fixed_alpha: False
+scale_mapping: "biased_softplus_1.0"

--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 import importlib
 import os
-
 import time
 from collections import OrderedDict
 from dataclasses import dataclass, MISSING
@@ -27,7 +26,6 @@ from tqdm import tqdm
 
 from benchmarl.algorithms.common import AlgorithmConfig
 from benchmarl.environments import Task
-
 from benchmarl.experiment.callback import Callback, CallbackNotifier
 from benchmarl.experiment.logger import Logger
 from benchmarl.models.common import ModelConfig
@@ -406,16 +404,7 @@ class Experiment(CallbackNotifier):
         self.test_env = test_env.to(self.config.sampling_device)
 
     def _setup_algorithm(self):
-        self.algorithm = self.algorithm_config.get_algorithm(
-            experiment_config=self.config,
-            model_config=self.model_config,
-            critic_model_config=self.critic_model_config,
-            observation_spec=self.observation_spec,
-            action_spec=self.action_spec,
-            state_spec=self.state_spec,
-            action_mask_spec=self.action_mask_spec,
-            group_map=self.group_map,
-        )
+        self.algorithm = self.algorithm_config.get_algorithm(experiment=self)
         self.replay_buffers = {
             group: self.algorithm.get_replay_buffer(
                 group=group,
@@ -493,7 +482,6 @@ class Experiment(CallbackNotifier):
             self.name = self.folder_name.name
 
     def _setup_logger(self):
-
         self.logger = Logger(
             experiment_name=self.name,
             folder_name=str(self.folder_name),
@@ -528,7 +516,6 @@ class Experiment(CallbackNotifier):
             raise err
 
     def _collection_loop(self):
-
         pbar = tqdm(
             initial=self.n_iters_performed,
             total=self.config.get_max_n_iters(self.on_policy),
@@ -537,7 +524,6 @@ class Experiment(CallbackNotifier):
 
         # Training/collection iterations
         for batch in self.collector:
-
             # Logging collection
             collection_time = time.time() - sampling_start
             current_frames = batch.numel()

--- a/benchmarl/models/common.py
+++ b/benchmarl/models/common.py
@@ -73,6 +73,7 @@ class Model(TensorDictModuleBase, ABC):
             or a different set of parameters for each agent.
             This is independent of the other options as it is possible to have different parameters
             for centralized critics with global input.
+        action_spec (CompositeSpec): The action spec of the environment
     """
 
     def __init__(
@@ -85,7 +86,7 @@ class Model(TensorDictModuleBase, ABC):
         centralised: bool,
         share_params: bool,
         device: DEVICE_TYPING,
-        **kwargs,
+        action_spec: CompositeSpec,
     ):
         TensorDictModuleBase.__init__(self)
 
@@ -97,6 +98,7 @@ class Model(TensorDictModuleBase, ABC):
         self.share_params = share_params
         self.device = device
         self.n_agents = n_agents
+        self.action_spec = action_spec
 
         self.in_keys = list(self.input_spec.keys(True, True))
         self.out_keys = list(self.output_spec.keys(True, True))
@@ -181,6 +183,7 @@ class SequenceModel(Model):
             device=models[0].device,
             agent_group=models[0].agent_group,
             input_has_agent_dim=models[0].input_has_agent_dim,
+            action_spec=models[0].action_spec,
         )
         self.models = TensorDictSequential(*models)
 
@@ -208,6 +211,7 @@ class ModelConfig(ABC):
         centralised: bool,
         share_params: bool,
         device: DEVICE_TYPING,
+        action_spec: CompositeSpec,
     ) -> Model:
         """
         Creates the model from the config.
@@ -230,6 +234,7 @@ class ModelConfig(ABC):
                 or a different set of parameters for each agent.
                 This is independent of the other options as it is possible to have different parameters
                 for centralized critics with global input.
+            action_spec (CompositeSpec): The action spec of the environment
 
         Returns: the Model
 
@@ -244,6 +249,7 @@ class ModelConfig(ABC):
             centralised=centralised,
             share_params=share_params,
             device=device,
+            action_spec=action_spec,
         )
 
     @staticmethod
@@ -314,6 +320,7 @@ class SequenceModelConfig(ModelConfig):
         centralised: bool,
         share_params: bool,
         device: DEVICE_TYPING,
+        action_spec: CompositeSpec,
     ) -> Model:
         n_models = len(self.model_configs)
         if not n_models > 0:
@@ -348,6 +355,7 @@ class SequenceModelConfig(ModelConfig):
                 centralised=centralised,
                 share_params=share_params,
                 device=device,
+                action_spec=action_spec,
             )
         ]
 
@@ -361,6 +369,7 @@ class SequenceModelConfig(ModelConfig):
                 centralised=next_centralised,
                 share_params=share_params,
                 device=device,
+                action_spec=action_spec,
             )
             for i in range(1, n_models)
         ]

--- a/benchmarl/models/common.py
+++ b/benchmarl/models/common.py
@@ -87,7 +87,6 @@ class Model(TensorDictModuleBase, ABC):
         share_params: bool,
         device: DEVICE_TYPING,
         experiment,
-        **kwargs,
     ):
         TensorDictModuleBase.__init__(self)
 

--- a/benchmarl/models/common.py
+++ b/benchmarl/models/common.py
@@ -73,6 +73,7 @@ class Model(TensorDictModuleBase, ABC):
             or a different set of parameters for each agent.
             This is independent of the other options as it is possible to have different parameters
             for centralized critics with global input.
+        experiment (Experiment): the current Experiment
     """
 
     def __init__(
@@ -85,10 +86,12 @@ class Model(TensorDictModuleBase, ABC):
         centralised: bool,
         share_params: bool,
         device: DEVICE_TYPING,
+        experiment,
         **kwargs,
     ):
         TensorDictModuleBase.__init__(self)
 
+        self.experiment = experiment
         self.input_spec = input_spec
         self.output_spec = output_spec
         self.agent_group = agent_group
@@ -172,7 +175,6 @@ class SequenceModel(Model):
         self,
         models: List[Model],
     ):
-
         super().__init__(
             n_agents=models[0].n_agents,
             input_spec=models[0].input_spec,
@@ -182,6 +184,7 @@ class SequenceModel(Model):
             device=models[0].device,
             agent_group=models[0].agent_group,
             input_has_agent_dim=models[0].input_has_agent_dim,
+            experiment=models[0].experiment,
         )
         self.models = TensorDictSequential(*models)
 
@@ -209,6 +212,7 @@ class ModelConfig(ABC):
         centralised: bool,
         share_params: bool,
         device: DEVICE_TYPING,
+        experiment,
     ) -> Model:
         """
         Creates the model from the config.
@@ -231,6 +235,7 @@ class ModelConfig(ABC):
                 or a different set of parameters for each agent.
                 This is independent of the other options as it is possible to have different parameters
                 for centralized critics with global input.
+            experiment (Experiment): the current Experiment
 
         Returns: the Model
 
@@ -245,6 +250,7 @@ class ModelConfig(ABC):
             centralised=centralised,
             share_params=share_params,
             device=device,
+            experiment=experiment,
         )
 
     @staticmethod
@@ -302,7 +308,6 @@ class ModelConfig(ABC):
 
 @dataclass
 class SequenceModelConfig(ModelConfig):
-
     model_configs: Sequence[ModelConfig]
     intermediate_sizes: Sequence[int]
 
@@ -316,8 +321,8 @@ class SequenceModelConfig(ModelConfig):
         centralised: bool,
         share_params: bool,
         device: DEVICE_TYPING,
+        experiment,
     ) -> Model:
-
         n_models = len(self.model_configs)
         if not n_models > 0:
             raise ValueError(
@@ -351,6 +356,7 @@ class SequenceModelConfig(ModelConfig):
                 centralised=centralised,
                 share_params=share_params,
                 device=device,
+                experiment=experiment,
             )
         ]
 
@@ -364,6 +370,7 @@ class SequenceModelConfig(ModelConfig):
                 centralised=next_centralised,
                 share_params=share_params,
                 device=device,
+                experiment=experiment,
             )
             for i in range(1, n_models)
         ]

--- a/benchmarl/models/common.py
+++ b/benchmarl/models/common.py
@@ -73,7 +73,6 @@ class Model(TensorDictModuleBase, ABC):
             or a different set of parameters for each agent.
             This is independent of the other options as it is possible to have different parameters
             for centralized critics with global input.
-        experiment (Experiment): the current Experiment
     """
 
     def __init__(
@@ -86,11 +85,10 @@ class Model(TensorDictModuleBase, ABC):
         centralised: bool,
         share_params: bool,
         device: DEVICE_TYPING,
-        experiment,
+        **kwargs,
     ):
         TensorDictModuleBase.__init__(self)
 
-        self.experiment = experiment
         self.input_spec = input_spec
         self.output_spec = output_spec
         self.agent_group = agent_group
@@ -183,7 +181,6 @@ class SequenceModel(Model):
             device=models[0].device,
             agent_group=models[0].agent_group,
             input_has_agent_dim=models[0].input_has_agent_dim,
-            experiment=models[0].experiment,
         )
         self.models = TensorDictSequential(*models)
 
@@ -211,7 +208,6 @@ class ModelConfig(ABC):
         centralised: bool,
         share_params: bool,
         device: DEVICE_TYPING,
-        experiment,
     ) -> Model:
         """
         Creates the model from the config.
@@ -234,7 +230,6 @@ class ModelConfig(ABC):
                 or a different set of parameters for each agent.
                 This is independent of the other options as it is possible to have different parameters
                 for centralized critics with global input.
-            experiment (Experiment): the current Experiment
 
         Returns: the Model
 
@@ -249,7 +244,6 @@ class ModelConfig(ABC):
             centralised=centralised,
             share_params=share_params,
             device=device,
-            experiment=experiment,
         )
 
     @staticmethod
@@ -320,7 +314,6 @@ class SequenceModelConfig(ModelConfig):
         centralised: bool,
         share_params: bool,
         device: DEVICE_TYPING,
-        experiment,
     ) -> Model:
         n_models = len(self.model_configs)
         if not n_models > 0:
@@ -355,7 +348,6 @@ class SequenceModelConfig(ModelConfig):
                 centralised=centralised,
                 share_params=share_params,
                 device=device,
-                experiment=experiment,
             )
         ]
 
@@ -369,7 +361,6 @@ class SequenceModelConfig(ModelConfig):
                 centralised=next_centralised,
                 share_params=share_params,
                 device=device,
-                experiment=experiment,
             )
             for i in range(1, n_models)
         ]

--- a/benchmarl/models/mlp.py
+++ b/benchmarl/models/mlp.py
@@ -31,6 +31,7 @@ class Mlp(Model):
             centralised=kwargs.pop("centralised"),
             share_params=kwargs.pop("share_params"),
             device=kwargs.pop("device"),
+            experiment=kwargs.pop("experiment"),
         )
 
         self.input_features = self.input_leaf_spec.shape[-1]

--- a/benchmarl/models/mlp.py
+++ b/benchmarl/models/mlp.py
@@ -31,7 +31,6 @@ class Mlp(Model):
             centralised=kwargs.pop("centralised"),
             share_params=kwargs.pop("share_params"),
             device=kwargs.pop("device"),
-            experiment=kwargs.pop("experiment"),
         )
 
         self.input_features = self.input_leaf_spec.shape[-1]

--- a/benchmarl/models/mlp.py
+++ b/benchmarl/models/mlp.py
@@ -31,6 +31,7 @@ class Mlp(Model):
             centralised=kwargs.pop("centralised"),
             share_params=kwargs.pop("share_params"),
             device=kwargs.pop("device"),
+            action_spec=kwargs.pop("action_spec"),
         )
 
         self.input_features = self.input_leaf_spec.shape[-1]

--- a/examples/extending/algorithm/custom_algorithm.py
+++ b/examples/extending/algorithm/custom_algorithm.py
@@ -31,6 +31,7 @@ class CustomIqlAlgorithm(Algorithm):
 
         # In all the class you have access to a lot of extra things like
         self.my_custom_method()  # Custom methods
+        _ = self.experiment  # Experiment class
         _ = self.experiment_config  # Experiment config
         _ = self.model_config  # Policy config
         _ = self.critic_model_config  # Eventual critic config
@@ -156,7 +157,6 @@ class CustomIqlAlgorithm(Algorithm):
     def _get_policy_for_collection(
         self, policy_for_loss: TensorDictModule, group: str, continuous: bool
     ) -> TensorDictModule:
-
         if self.action_mask_spec is not None:
             action_mask_key = (group, "action_mask")
         else:

--- a/examples/extending/model/custom_model.py
+++ b/examples/extending/model/custom_model.py
@@ -39,6 +39,7 @@ class CustomModel(Model):
         # And access some of the ones already available to your module
         _ = self.input_spec  # Like its input_spec
         _ = self.output_spec  # or output_spec
+        _ = self.action_spec  # the action spec of the env
         _ = self.agent_group  # the name of the agent group the model is for
         _ = self.n_agents  # or the number of agents this module is for
 


### PR DESCRIPTION
This PR makes it so that the whole experiment object is passed to algorithms in order to increment the available inoformation to a user implementing a custom algoritim.

Furtermore it:
- makes the scale transformation in probabilistic algorithms customizable by the user
- allow models to access the action spec