### PR TITLE
[BugFix] Use correct types to prevent multiwalker init error.

### DIFF
--- a/benchmarl/environments/pettingzoo/multiwalker.py
+++ b/benchmarl/environments/pettingzoo/multiwalker.py
@@ -20,4 +20,4 @@ class TaskConfig:
     terminate_reward: float = MISSING
     terminate_on_fall: bool = MISSING
     remove_on_fall: bool = MISSING
-    terrain_length: float = MISSING
+    terrain_length: int = MISSING


### PR DESCRIPTION
Closes https://github.com/facebookresearch/BenchMARL/issues/46. 