### PR TITLE
[CI] Run main tests with torchrl nightly and have a separate CI for testing torchrl stable

### DIFF
--- a/.github/unittest/install_dependencies_nightly.sh
+++ b/.github/unittest/install_dependencies_nightly.sh
@@ -7,7 +7,10 @@ if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 python -m pip install --pre torch --extra-index-url https://download.pytorch.org/whl/nightly/cpu --force-reinstall
 
-pip install torchrl
-
+cd ..
+python -m pip install git+https://github.com/pytorch-labs/tensordict.git
+git clone https://github.com/pytorch/rl.git
+cd rl
+python setup.py develop
 cd ../BenchMARL
 pip install -e .

--- a/.github/unittest/install_vmas.sh
+++ b/.github/unittest/install_vmas.sh
@@ -1,4 +1,4 @@
 
-python -m pip install git+https://github.com/proroklab/VectorizedMultiAgentSimulator.git
+python -m pip install vmas
 sudo apt-get update
 sudo apt-get install python3-opengl xvfb

--- a/.github/workflows/pettingzoo_tests.yml
+++ b/.github/workflows/pettingzoo_tests.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-       bash .github/unittest/install_dependencies.sh
+       bash .github/unittest/install_dependencies_nightly.sh
     - name: Install pettingzoo
       run: |
        bash .github/unittest/install_pettingzoo.sh

--- a/.github/workflows/smacv2_tests.yml
+++ b/.github/workflows/smacv2_tests.yml
@@ -31,7 +31,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-       bash .github/unittest/install_dependencies.sh
+       bash .github/unittest/install_dependencies_nightly.sh
     - name: Install smacv2
       run: |
        bash .github/unittest/install_smacv2.sh

--- a/.github/workflows/torchrl_nightly.yml
+++ b/.github/workflows/torchrl_nightly.yml
@@ -1,0 +1,63 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see:
+# https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+
+name: vmas_tests
+
+on:
+  push:
+    branches: [ $default-branch , "main" ]
+  pull_request:
+    branches: [ $default-branch , "main" ]
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+       bash .github/unittest/install_dependencies_nightly.sh
+    - name: Install vmas
+      run: |
+       bash .github/unittest/install_vmas.sh
+    - name: Install pettingzoo
+      run: |
+        bash .github/unittest/install_pettingzoo.sh
+    - if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'smacv2') }}
+      name: Install smacv2
+      run: |
+        bash .github/unittest/install_smacv2.sh
+
+    - name: Unit tests
+      run: |
+        pytest test/ --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+
+    - name: Vmas tests
+      run: |
+        xvfb-run -s "-screen 0 1024x768x24" pytest test/test_vmas.py --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+
+    - name: PettingZoo tests
+      run: |
+        xvfb-run -s "-screen 0 1024x768x24" pytest test/test_pettingzoo.py --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+
+    - if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'smacv2') }}
+      name: Test with pytest
+      run: |
+        root_dir="$(git rev-parse --show-toplevel)"
+        export SC2PATH="${root_dir}/StarCraftII"
+        echo 'SC2PATH is set to ' "$SC2PATH"
+        
+        pytest test/test_smacv2.py --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html

--- a/.github/workflows/torchrl_nightly.yml
+++ b/.github/workflows/torchrl_nightly.yml
@@ -54,7 +54,7 @@ jobs:
         xvfb-run -s "-screen 0 1024x768x24" pytest test/test_pettingzoo.py --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
 
     - if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'smacv2') }}
-      name: Test with pytest
+      name: SMACv2 tests
       run: |
         root_dir="$(git rev-parse --show-toplevel)"
         export SC2PATH="${root_dir}/StarCraftII"

--- a/.github/workflows/torchrl_nightly_tests.yml
+++ b/.github/workflows/torchrl_nightly_tests.yml
@@ -3,7 +3,7 @@
 # https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 
-name: vmas_tests
+name: torchrl_nightly_tests
 
 on:
   push:

--- a/.github/workflows/torchrl_stable_tests.yml
+++ b/.github/workflows/torchrl_stable_tests.yml
@@ -43,21 +43,8 @@ jobs:
 
     - name: Unit tests
       run: |
-        pytest test/ --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
-
-    - name: Vmas tests
-      run: |
-        xvfb-run -s "-screen 0 1024x768x24" pytest test/test_vmas.py -k 'not gnn' --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
-
-    - name: PettingZoo tests
-      run: |
-        xvfb-run -s "-screen 0 1024x768x24" pytest test/test_pettingzoo.py -k 'not gnn' --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
-
-    - if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'smacv2') }}
-      name: SMACv2 tests
-      run: |
         root_dir="$(git rev-parse --show-toplevel)"
         export SC2PATH="${root_dir}/StarCraftII"
         echo 'SC2PATH is set to ' "$SC2PATH"
         
-        pytest test/test_smacv2.py -k 'not gnn' --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+        xvfb-run -s "-screen 0 1024x768x24 pytest test/ --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html

--- a/.github/workflows/torchrl_stable_tests.yml
+++ b/.github/workflows/torchrl_stable_tests.yml
@@ -47,4 +47,4 @@ jobs:
         export SC2PATH="${root_dir}/StarCraftII"
         echo 'SC2PATH is set to ' "$SC2PATH"
         
-        xvfb-run -s "-screen 0 1024x768x24" pytest test/ -k 'not gnn' --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+        xvfb-run -s "-screen 0 1024x768x24" pytest test/ --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html

--- a/.github/workflows/torchrl_stable_tests.yml
+++ b/.github/workflows/torchrl_stable_tests.yml
@@ -47,4 +47,4 @@ jobs:
         export SC2PATH="${root_dir}/StarCraftII"
         echo 'SC2PATH is set to ' "$SC2PATH"
         
-        xvfb-run -s "-screen 0 1024x768x24 pytest test/ -k 'not gnn' --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+        xvfb-run -s "-screen 0 1024x768x24" pytest test/ -k 'not gnn' --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html

--- a/.github/workflows/torchrl_stable_tests.yml
+++ b/.github/workflows/torchrl_stable_tests.yml
@@ -3,7 +3,7 @@
 # https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
 
-name: torchrl_nightly_tests
+name: torchrl_stable_tests
 
 on:
   push:
@@ -29,7 +29,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-       bash .github/unittest/install_dependencies_nightly.sh
+       bash .github/unittest/install_dependencies.sh
     - name: Install vmas
       run: |
        bash .github/unittest/install_vmas.sh
@@ -47,11 +47,11 @@ jobs:
 
     - name: Vmas tests
       run: |
-        xvfb-run -s "-screen 0 1024x768x24" pytest test/test_vmas.py --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+        xvfb-run -s "-screen 0 1024x768x24" pytest test/test_vmas.py -k 'not gnn' --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
 
     - name: PettingZoo tests
       run: |
-        xvfb-run -s "-screen 0 1024x768x24" pytest test/test_pettingzoo.py --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+        xvfb-run -s "-screen 0 1024x768x24" pytest test/test_pettingzoo.py -k 'not gnn' --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
 
     - if: ${{ github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'smacv2') }}
       name: SMACv2 tests
@@ -60,4 +60,4 @@ jobs:
         export SC2PATH="${root_dir}/StarCraftII"
         echo 'SC2PATH is set to ' "$SC2PATH"
         
-        pytest test/test_smacv2.py --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+        pytest test/test_smacv2.py -k 'not gnn' --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html

--- a/.github/workflows/torchrl_stable_tests.yml
+++ b/.github/workflows/torchrl_stable_tests.yml
@@ -47,4 +47,4 @@ jobs:
         export SC2PATH="${root_dir}/StarCraftII"
         echo 'SC2PATH is set to ' "$SC2PATH"
         
-        xvfb-run -s "-screen 0 1024x768x24 pytest test/ --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html
+        xvfb-run -s "-screen 0 1024x768x24 pytest test/ -k 'not gnn' --doctest-modules --junitxml=junit/test-results.xml --cov=. --cov-report=xml --cov-report=html

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-       bash .github/unittest/install_dependencies.sh
+       bash .github/unittest/install_dependencies_nightly.sh
 
     - name: Test with pytest
       run: |

--- a/.github/workflows/vmas_tests.yml
+++ b/.github/workflows/vmas_tests.yml
@@ -30,7 +30,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
-       bash .github/unittest/install_dependencies.sh
+       bash .github/unittest/install_dependencies_nightly.sh
     - name: Install vmas
       run: |
        bash .github/unittest/install_vmas.sh


### PR DESCRIPTION
BenchMARL development is based on torchrl nightly. In the same way that torchrl is based on tensordict.

In this PR we add a CI to test against torchrl stable as well.

In the current stage, this CI skips GNN tests as torch_geometric is not supperted in any torchrl stable version as of now

cc @vmoens 