### PR TITLE
[Feature] Allow any name for observation and global_state keys

### DIFF
--- a/benchmarl/algorithms/common.py
+++ b/benchmarl/algorithms/common.py
@@ -59,22 +59,16 @@ class Algorithm(ABC):
 
     def _check_specs(self):
         if self.state_spec is not None:
-            if (
-                len(self.state_spec.keys(True, True)) != 1
-                or list(self.state_spec.keys())[0] != "state"
-            ):
+            if len(self.state_spec.keys(True, True)) != 1:
                 raise ValueError(
-                    "State spec must contain one entry per group named 'state'"
+                    "State spec must contain one entry per group"
                     " to follow the library conventions, "
                     "you can apply a transform to your environment to satisfy this criteria."
                 )
         for group in self.group_map.keys():
-            if (
-                len(self.observation_spec[group].keys(True, True)) != 1
-                or list(self.observation_spec[group].keys())[0] != "observation"
-            ):
+            if len(self.observation_spec[group].keys(True, True)) != 1:
                 raise ValueError(
-                    "Observation spec must contain one entry per group named 'observation'"
+                    "Observation spec must contain one entry per group"
                     " to follow the library conventions, "
                     "you can apply a transform to your environment to satisfy this criteria."
                 )

--- a/benchmarl/algorithms/iddpg.py
+++ b/benchmarl/algorithms/iddpg.py
@@ -188,7 +188,7 @@ class Iddpg(Algorithm):
     def get_value_module(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
         modules = []
-        group_observation_key = self.observation_spec[group].keys()[0]
+        group_observation_key = list(self.observation_spec[group].keys())[0]
 
         modules.append(
             TensorDictModule(

--- a/benchmarl/algorithms/iddpg.py
+++ b/benchmarl/algorithms/iddpg.py
@@ -96,16 +96,7 @@ class Iddpg(Algorithm):
             n_agents = len(self.group_map[group])
             logits_shape = list(self.action_spec[group, "action"].shape)
             actor_input_spec = CompositeSpec(
-                {
-                    group: CompositeSpec(
-                        {
-                            "observation": self.observation_spec[group]["observation"]
-                            .clone()
-                            .to(self.device)
-                        },
-                        shape=(n_agents,),
-                    )
-                }
+                {group: self.observation_spec[group].clone().to(self.device)}
             )
             actor_output_spec = CompositeSpec(
                 {
@@ -197,11 +188,15 @@ class Iddpg(Algorithm):
     def get_value_module(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
         modules = []
+        group_observation_key = self.observation_spec[group].keys()[0]
 
         modules.append(
             TensorDictModule(
                 lambda obs, action: torch.cat([obs, action], dim=-1),
-                in_keys=[(group, "observation"), (group, "action")],
+                in_keys=[
+                    (group, group_observation_key),
+                    (group, "action"),
+                ],
                 out_keys=[(group, "obs_action")],
             )
         )
@@ -212,7 +207,9 @@ class Iddpg(Algorithm):
                         "obs_action": UnboundedContinuousTensorSpec(
                             shape=(
                                 n_agents,
-                                self.observation_spec[group, "observation"].shape[-1]
+                                self.observation_spec[
+                                    group, group_observation_key
+                                ].shape[-1]
                                 + self.action_spec[group, "action"].shape[-1],
                             )
                         )

--- a/benchmarl/algorithms/ippo.py
+++ b/benchmarl/algorithms/ippo.py
@@ -114,16 +114,7 @@ class Ippo(Algorithm):
             ]
 
         actor_input_spec = CompositeSpec(
-            {
-                group: CompositeSpec(
-                    {
-                        "observation": self.observation_spec[group]["observation"]
-                        .clone()
-                        .to(self.device)
-                    },
-                    shape=(n_agents,),
-                )
-            }
+            {group: self.observation_spec[group].clone().to(self.device)}
         )
 
         actor_output_spec = CompositeSpec(
@@ -257,16 +248,7 @@ class Ippo(Algorithm):
         n_agents = len(self.group_map[group])
 
         critic_input_spec = CompositeSpec(
-            {
-                group: CompositeSpec(
-                    {
-                        "observation": self.observation_spec[group]["observation"]
-                        .clone()
-                        .to(self.device)
-                    },
-                    shape=(n_agents,),
-                )
-            }
+            {group: self.observation_spec[group].clone().to(self.device)}
         )
         critic_output_spec = CompositeSpec(
             {

--- a/benchmarl/algorithms/iql.py
+++ b/benchmarl/algorithms/iql.py
@@ -78,16 +78,7 @@ class Iql(Algorithm):
         ]
 
         actor_input_spec = CompositeSpec(
-            {
-                group: CompositeSpec(
-                    {
-                        "observation": self.observation_spec[group]["observation"]
-                        .clone()
-                        .to(self.device)
-                    },
-                    shape=(n_agents,),
-                )
-            }
+            {group: self.observation_spec[group].clone().to(self.device)}
         )
 
         actor_output_spec = CompositeSpec(

--- a/benchmarl/algorithms/isac.py
+++ b/benchmarl/algorithms/isac.py
@@ -166,16 +166,7 @@ class Isac(Algorithm):
             ]
 
         actor_input_spec = CompositeSpec(
-            {
-                group: CompositeSpec(
-                    {
-                        "observation": self.observation_spec[group]["observation"]
-                        .clone()
-                        .to(self.device)
-                    },
-                    shape=(n_agents,),
-                )
-            }
+            {group: self.observation_spec[group].clone().to(self.device)}
         )
 
         actor_output_spec = CompositeSpec(
@@ -292,16 +283,7 @@ class Isac(Algorithm):
         n_actions = self.action_spec[group, "action"].space.n
 
         critic_input_spec = CompositeSpec(
-            {
-                group: CompositeSpec(
-                    {
-                        "observation": self.observation_spec[group]["observation"]
-                        .clone()
-                        .to(self.device)
-                    },
-                    shape=(n_agents,),
-                )
-            }
+            {group: self.observation_spec[group].clone().to(self.device)}
         )
 
         critic_output_spec = CompositeSpec(
@@ -333,11 +315,12 @@ class Isac(Algorithm):
     def get_continuous_value_module(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
         modules = []
+        group_observation_key = self.observation_spec[group].keys()[0]
 
         modules.append(
             TensorDictModule(
                 lambda obs, action: torch.cat([obs, action], dim=-1),
-                in_keys=[(group, "observation"), (group, "action")],
+                in_keys=[(group, group_observation_key), (group, "action")],
                 out_keys=[(group, "obs_action")],
             )
         )
@@ -348,7 +331,9 @@ class Isac(Algorithm):
                         "obs_action": UnboundedContinuousTensorSpec(
                             shape=(
                                 n_agents,
-                                self.observation_spec[group, "observation"].shape[-1]
+                                self.observation_spec[
+                                    group, group_observation_key
+                                ].shape[-1]
                                 + self.action_spec[group, "action"].shape[-1],
                             )
                         )

--- a/benchmarl/algorithms/isac.py
+++ b/benchmarl/algorithms/isac.py
@@ -315,7 +315,7 @@ class Isac(Algorithm):
     def get_continuous_value_module(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
         modules = []
-        group_observation_key = self.observation_spec[group].keys()[0]
+        group_observation_key = list(self.observation_spec[group].keys())[0]
 
         modules.append(
             TensorDictModule(

--- a/benchmarl/algorithms/maddpg.py
+++ b/benchmarl/algorithms/maddpg.py
@@ -96,16 +96,7 @@ class Maddpg(Algorithm):
             n_agents = len(self.group_map[group])
             logits_shape = list(self.action_spec[group, "action"].shape)
             actor_input_spec = CompositeSpec(
-                {
-                    group: CompositeSpec(
-                        {
-                            "observation": self.observation_spec[group]["observation"]
-                            .clone()
-                            .to(self.device)
-                        },
-                        shape=(n_agents,),
-                    )
-                }
+                {group: self.observation_spec[group].clone().to(self.device)}
             )
             actor_output_spec = CompositeSpec(
                 {
@@ -197,6 +188,8 @@ class Maddpg(Algorithm):
     def get_value_module(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
         modules = []
+        group_observation_key = self.observation_spec[group].keys()[0]
+        global_state_key = self.state_spec.keys()[0]
 
         if self.share_param_critic:
             critic_output_spec = CompositeSpec(
@@ -222,7 +215,7 @@ class Maddpg(Algorithm):
                     lambda state, action: torch.cat(
                         [state, action.reshape(*action.shape[:-2], -1)], dim=-1
                     ),
-                    in_keys=["state", (group, "action")],
+                    in_keys=[global_state_key, (group, "action")],
                     out_keys=["state_action"],
                 )
             )
@@ -230,7 +223,7 @@ class Maddpg(Algorithm):
                 {
                     "state_action": UnboundedContinuousTensorSpec(
                         shape=(
-                            self.state_spec["state"].shape[-1]
+                            self.state_spec[global_state_key].shape[-1]
                             + self.action_spec[group, "action"].shape[-1] * n_agents,
                         )
                     )
@@ -255,7 +248,7 @@ class Maddpg(Algorithm):
             modules.append(
                 TensorDictModule(
                     lambda obs, action: torch.cat([obs, action], dim=-1),
-                    in_keys=[(group, "observation"), (group, "action")],
+                    in_keys=[(group, group_observation_key), (group, "action")],
                     out_keys=[(group, "obs_action")],
                 )
             )
@@ -266,9 +259,9 @@ class Maddpg(Algorithm):
                             "obs_action": UnboundedContinuousTensorSpec(
                                 shape=(
                                     n_agents,
-                                    self.observation_spec[group, "observation"].shape[
-                                        -1
-                                    ]
+                                    self.observation_spec[
+                                        group, group_observation_key
+                                    ].shape[-1]
                                     + self.action_spec[group, "action"].shape[-1],
                                 )
                             )

--- a/benchmarl/algorithms/maddpg.py
+++ b/benchmarl/algorithms/maddpg.py
@@ -189,7 +189,6 @@ class Maddpg(Algorithm):
         n_agents = len(self.group_map[group])
         modules = []
         group_observation_key = self.observation_spec[group].keys()[0]
-        global_state_key = self.state_spec.keys()[0]
 
         if self.share_param_critic:
             critic_output_spec = CompositeSpec(
@@ -210,6 +209,7 @@ class Maddpg(Algorithm):
             )
 
         if self.state_spec is not None:
+            global_state_key = self.state_spec.keys()[0]
             modules.append(
                 TensorDictModule(
                     lambda state, action: torch.cat(

--- a/benchmarl/algorithms/maddpg.py
+++ b/benchmarl/algorithms/maddpg.py
@@ -188,7 +188,7 @@ class Maddpg(Algorithm):
     def get_value_module(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
         modules = []
-        group_observation_key = self.observation_spec[group].keys()[0]
+        group_observation_key = list(self.observation_spec[group].keys())[0]
 
         if self.share_param_critic:
             critic_output_spec = CompositeSpec(

--- a/benchmarl/algorithms/maddpg.py
+++ b/benchmarl/algorithms/maddpg.py
@@ -209,7 +209,7 @@ class Maddpg(Algorithm):
             )
 
         if self.state_spec is not None:
-            global_state_key = self.state_spec.keys()[0]
+            global_state_key = list(self.state_spec.keys())[0]
             modules.append(
                 TensorDictModule(
                     lambda state, action: torch.cat(

--- a/benchmarl/algorithms/mappo.py
+++ b/benchmarl/algorithms/mappo.py
@@ -118,16 +118,7 @@ class Mappo(Algorithm):
             ]
 
         actor_input_spec = CompositeSpec(
-            {
-                group: CompositeSpec(
-                    {
-                        "observation": self.observation_spec[group]["observation"]
-                        .clone()
-                        .to(self.device)
-                    },
-                    shape=(n_agents,),
-                )
-            }
+            {group: self.observation_spec[group].clone().to(self.device)}
         )
 
         actor_output_spec = CompositeSpec(
@@ -292,16 +283,7 @@ class Mappo(Algorithm):
 
         else:
             critic_input_spec = CompositeSpec(
-                {
-                    group: CompositeSpec(
-                        {
-                            "observation": self.observation_spec[group]["observation"]
-                            .clone()
-                            .to(self.device)
-                        },
-                        shape=(n_agents,),
-                    )
-                }
+                {group: self.observation_spec[group].clone().to(self.device)}
             )
             value_module = self.critic_model_config.get_model(
                 input_spec=critic_input_spec,

--- a/benchmarl/algorithms/masac.py
+++ b/benchmarl/algorithms/masac.py
@@ -342,7 +342,7 @@ class Masac(Algorithm):
     def get_continuous_value_module(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
         modules = []
-        group_observation_key = self.observation_spec[group].keys()[0]
+        group_observation_key = list(self.observation_spec[group].keys())[0]
 
         if self.share_param_critic:
             critic_output_spec = CompositeSpec(

--- a/benchmarl/algorithms/masac.py
+++ b/benchmarl/algorithms/masac.py
@@ -363,7 +363,7 @@ class Masac(Algorithm):
             )
 
         if self.state_spec is not None:
-            global_state_key = self.state_spec.keys()[0]
+            global_state_key = list(self.state_spec.keys())[0]
             modules.append(
                 TensorDictModule(
                     lambda state, action: torch.cat(

--- a/benchmarl/algorithms/masac.py
+++ b/benchmarl/algorithms/masac.py
@@ -343,7 +343,6 @@ class Masac(Algorithm):
         n_agents = len(self.group_map[group])
         modules = []
         group_observation_key = self.observation_spec[group].keys()[0]
-        global_state_key = self.state_spec.keys()[0]
 
         if self.share_param_critic:
             critic_output_spec = CompositeSpec(
@@ -364,6 +363,7 @@ class Masac(Algorithm):
             )
 
         if self.state_spec is not None:
+            global_state_key = self.state_spec.keys()[0]
             modules.append(
                 TensorDictModule(
                     lambda state, action: torch.cat(

--- a/benchmarl/algorithms/masac.py
+++ b/benchmarl/algorithms/masac.py
@@ -166,16 +166,7 @@ class Masac(Algorithm):
             ]
 
         actor_input_spec = CompositeSpec(
-            {
-                group: CompositeSpec(
-                    {
-                        "observation": self.observation_spec[group]["observation"]
-                        .clone()
-                        .to(self.device)
-                    },
-                    shape=(n_agents,),
-                )
-            }
+            {group: self.observation_spec[group].clone().to(self.device)}
         )
 
         actor_output_spec = CompositeSpec(
@@ -323,16 +314,7 @@ class Masac(Algorithm):
 
         else:
             critic_input_spec = CompositeSpec(
-                {
-                    group: CompositeSpec(
-                        {
-                            "observation": self.observation_spec[group]["observation"]
-                            .clone()
-                            .to(self.device)
-                        },
-                        shape=(n_agents,),
-                    )
-                }
+                {group: self.observation_spec[group].clone().to(self.device)}
             )
             value_module = self.critic_model_config.get_model(
                 input_spec=critic_input_spec,
@@ -360,6 +342,8 @@ class Masac(Algorithm):
     def get_continuous_value_module(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
         modules = []
+        group_observation_key = self.observation_spec[group].keys()[0]
+        global_state_key = self.state_spec.keys()[0]
 
         if self.share_param_critic:
             critic_output_spec = CompositeSpec(
@@ -385,7 +369,7 @@ class Masac(Algorithm):
                     lambda state, action: torch.cat(
                         [state, action.reshape(*action.shape[:-2], -1)], dim=-1
                     ),
-                    in_keys=["state", (group, "action")],
+                    in_keys=[global_state_key, (group, "action")],
                     out_keys=["state_action"],
                 )
             )
@@ -393,7 +377,7 @@ class Masac(Algorithm):
                 {
                     "state_action": UnboundedContinuousTensorSpec(
                         shape=(
-                            self.state_spec["state"].shape[-1]
+                            self.state_spec[global_state_key].shape[-1]
                             + self.action_spec[group, "action"].shape[-1] * n_agents,
                         )
                     )
@@ -418,7 +402,7 @@ class Masac(Algorithm):
             modules.append(
                 TensorDictModule(
                     lambda obs, action: torch.cat([obs, action], dim=-1),
-                    in_keys=[(group, "observation"), (group, "action")],
+                    in_keys=[(group, group_observation_key), (group, "action")],
                     out_keys=[(group, "obs_action")],
                 )
             )
@@ -429,9 +413,9 @@ class Masac(Algorithm):
                             "obs_action": UnboundedContinuousTensorSpec(
                                 shape=(
                                     n_agents,
-                                    self.observation_spec[group, "observation"].shape[
-                                        -1
-                                    ]
+                                    self.observation_spec[
+                                        group, group_observation_key
+                                    ].shape[-1]
                                     + self.action_spec[group, "action"].shape[-1],
                                 )
                             )

--- a/benchmarl/algorithms/qmix.py
+++ b/benchmarl/algorithms/qmix.py
@@ -180,7 +180,7 @@ class Qmix(Algorithm):
         group_observation_key = list(self.observation_spec[group].keys())[0]
 
         if self.state_spec is not None:
-            global_state_key = self.state_spec.keys()[0]
+            global_state_key = list(self.state_spec.keys())[0]
             state_shape = self.state_spec[global_state_key].shape
             in_keys = [(group, "chosen_action_value"), global_state_key]
         else:

--- a/benchmarl/algorithms/qmix.py
+++ b/benchmarl/algorithms/qmix.py
@@ -178,9 +178,9 @@ class Qmix(Algorithm):
     def get_mixer(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
         group_observation_key = self.observation_spec[group].keys()[0]
-        global_state_key = self.state_spec.keys()[0]
 
         if self.state_spec is not None:
+            global_state_key = self.state_spec.keys()[0]
             state_shape = self.state_spec[global_state_key].shape
             in_keys = [(group, "chosen_action_value"), global_state_key]
         else:

--- a/benchmarl/algorithms/qmix.py
+++ b/benchmarl/algorithms/qmix.py
@@ -177,7 +177,7 @@ class Qmix(Algorithm):
 
     def get_mixer(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
-        group_observation_key = self.observation_spec[group].keys()[0]
+        group_observation_key = list(self.observation_spec[group].keys())[0]
 
         if self.state_spec is not None:
             global_state_key = self.state_spec.keys()[0]

--- a/benchmarl/algorithms/qmix.py
+++ b/benchmarl/algorithms/qmix.py
@@ -84,16 +84,7 @@ class Qmix(Algorithm):
         ]
 
         actor_input_spec = CompositeSpec(
-            {
-                group: CompositeSpec(
-                    {
-                        "observation": self.observation_spec[group]["observation"]
-                        .clone()
-                        .to(self.device)
-                    },
-                    shape=(n_agents,),
-                )
-            }
+            {group: self.observation_spec[group].clone().to(self.device)}
         )
 
         actor_output_spec = CompositeSpec(
@@ -186,13 +177,15 @@ class Qmix(Algorithm):
 
     def get_mixer(self, group: str) -> TensorDictModule:
         n_agents = len(self.group_map[group])
+        group_observation_key = self.observation_spec[group].keys()[0]
+        global_state_key = self.state_spec.keys()[0]
 
         if self.state_spec is not None:
-            state_shape = self.state_spec["state"].shape
-            in_keys = [(group, "chosen_action_value"), "state"]
+            state_shape = self.state_spec[global_state_key].shape
+            in_keys = [(group, "chosen_action_value"), global_state_key]
         else:
-            state_shape = self.observation_spec[group, "observation"].shape
-            in_keys = [(group, "chosen_action_value"), (group, "observation")]
+            state_shape = self.observation_spec[group, group_observation_key].shape
+            in_keys = [(group, "chosen_action_value"), (group, group_observation_key)]
 
         mixer = TensorDictModule(
             module=QMixer(

--- a/benchmarl/algorithms/vdn.py
+++ b/benchmarl/algorithms/vdn.py
@@ -82,16 +82,7 @@ class Vdn(Algorithm):
         ]
 
         actor_input_spec = CompositeSpec(
-            {
-                group: CompositeSpec(
-                    {
-                        "observation": self.observation_spec[group]["observation"]
-                        .clone()
-                        .to(self.device)
-                    },
-                    shape=(n_agents,),
-                )
-            }
+            {group: self.observation_spec[group].clone().to(self.device)}
         )
 
         actor_output_spec = CompositeSpec(

--- a/benchmarl/environments/common.py
+++ b/benchmarl/environments/common.py
@@ -156,7 +156,7 @@ class Task(Enum):
     def observation_spec(self, env: EnvBase) -> CompositeSpec:
         """
         A spec for the observation.
-        Must be a CompositeSpec with one (group_name, "observation") entry per group.
+        Must be a CompositeSpec with one (group_name, observation_key) entry per group.
 
         Args:
             env (EnvBase): An environment created via self.get_env_fun
@@ -179,7 +179,7 @@ class Task(Enum):
     def state_spec(self, env: EnvBase) -> Optional[CompositeSpec]:
         """
         A spec for the state.
-        If provided, must be a CompositeSpec with one "state" entry.
+        If provided, must be a CompositeSpec with one entry.
 
         Args:
             env (EnvBase): An environment created via self.get_env_fun

--- a/examples/extending/algorithm/custom_algorithm.py
+++ b/examples/extending/algorithm/custom_algorithm.py
@@ -103,16 +103,7 @@ class CustomIqlAlgorithm(Algorithm):
 
         # This is the spec of the policy input for this group
         actor_input_spec = CompositeSpec(
-            {
-                group: CompositeSpec(
-                    {
-                        "observation": self.observation_spec[group]["observation"]
-                        .clone()
-                        .to(self.device)
-                    },
-                    shape=(n_agents,),
-                )
-            }
+            {group: self.observation_spec[group].clone().to(self.device)}
         )
         # This is the spec of the policy output for this group
         actor_output_spec = CompositeSpec(

--- a/examples/extending/task/custom_task.py
+++ b/examples/extending/task/custom_task.py
@@ -62,7 +62,7 @@ class CustomEnvTask(Task):
 
     def observation_spec(self, env: EnvBase) -> CompositeSpec:
         # A spec for the observation.
-        # Must be a CompositeSpec with one (group_name, "observation") entry per group.
+        # Must be a CompositeSpec with one (group_name, observation_key) entry per group.
         return env.full_observation_spec
 
     def action_spec(self, env: EnvBase) -> CompositeSpec:


### PR DESCRIPTION
This PR allows any name for the group observation key and the global state key.

Before benchmarl constrained the observation to be named "observation" and the global state to be named "state"

cc @ezhang7423