### PR TITLE
[Feature] Disable pre-compute advantage PPO

### DIFF
--- a/benchmarl/conf/algorithm/ippo.yaml
+++ b/benchmarl/conf/algorithm/ippo.yaml
@@ -11,3 +11,4 @@ loss_critic_type: "l2"
 lmbda: 0.9
 scale_mapping: "biased_softplus_1.0"
 use_tanh_normal: True
+pre_compute_advantage: False

--- a/benchmarl/conf/algorithm/mappo.yaml
+++ b/benchmarl/conf/algorithm/mappo.yaml
@@ -12,3 +12,4 @@ loss_critic_type: "l2"
 lmbda: 0.9
 scale_mapping: "biased_softplus_1.0"
 use_tanh_normal: True
+pre_compute_advantage: False


### PR DESCRIPTION
When advantage is pre-computed on massive batch sizes with non-trivial models this can require an unreasonable amount of memory

- [ ] Check results remain the same