### PR TITLE
[Feature] Run evaluation on first iteration

### DIFF
--- a/.github/unittest/install_vmas.sh
+++ b/.github/unittest/install_vmas.sh
@@ -1,4 +1,4 @@
 
-python -m pip install vmas
+python -m pip install vmas matplotlib==3.8
 sudo apt-get update
 sudo apt-get install python3-opengl xvfb

--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -657,7 +657,10 @@ class Experiment(CallbackNotifier):
             # Evaluation
             if (
                 self.config.evaluation
-                and (self.total_frames % self.config.evaluation_interval == 0)
+                and (
+                    self.total_frames % self.config.evaluation_interval == 0
+                    or self.n_iters_performed == 0
+                )
                 and (len(self.config.loggers) or self.config.create_json)
             ):
                 self._evaluation_loop()


### PR DESCRIPTION
The majority of users seems to be wanting to see evaluation results on the first iteration.

So this PR runs evaluation also on first iter and then every `evaluation_interval` frames