### PR TITLE
[BugFix] GNN position and velocity key 

### DIFF
--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -734,6 +734,7 @@ class Experiment(CallbackNotifier):
         for other_group in self.group_map.keys():
             if other_group != group:
                 excluded_keys += [other_group, ("next", other_group)]
+        excluded_keys += ["info", (group, "info"), ("next", group, "info")]
         return excluded_keys
 
     def _optimizer_loop(self, group: str) -> TensorDictBase:

--- a/benchmarl/models/gnn.py
+++ b/benchmarl/models/gnn.py
@@ -287,7 +287,6 @@ class Gnn(Model):
                         f"Position key in tensordict is {pos.shape[-1]}-dimensional, "
                         f"while model was configured with pos_features={self.pos_features-1}"
                     )
-                print(self._full_position_key)
             else:
                 pos = tensordict.get(self._full_position_key)
             if not self.exclude_pos_from_node_features:

--- a/benchmarl/models/gnn.py
+++ b/benchmarl/models/gnn.py
@@ -287,6 +287,7 @@ class Gnn(Model):
                         f"Position key in tensordict is {pos.shape[-1]}-dimensional, "
                         f"while model was configured with pos_features={self.pos_features-1}"
                     )
+                print(self._full_position_key)
             else:
                 pos = tensordict.get(self._full_position_key)
             if not self.exclude_pos_from_node_features:
@@ -380,7 +381,8 @@ class Gnn(Model):
             ):
                 return k
         raise KeyError(
-            f"Key terminating with {key} and containing {self.agent_group} not found in keys: {keys}"
+            f"Key terminating with {key} and containing {self.agent_group} not found in keys: {keys}. "
+            f"If you are using the GNN in a `SequenceModel` and want to use this key, it needs to be the first model."
         )
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,7 @@ toc_object_entries = False
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
-    "torch": ("https://pytorch.org/docs/master", None),
+    "torch": ("https://pytorch.org/docs/stable/", None),
     "torchrl": ("https://pytorch.org/rl/stable/", None),
     "tensordict": ("https://pytorch.org/tensordict/stable", None),
 }


### PR DESCRIPTION
This PR amends #125 which suggested to include position key and velocity key in gnns in the info dict.

This solution is not feasible as torchrl impedes access to this information in some losses.

The current supported way to include these keys in as part of the observations.

**This will however require the GNN to be the first in the sequence if `SequenceModel` is used**