### PR TITLE
[BugFix] More flexible episode_reward computation in logger

### DIFF
--- a/benchmarl/experiment/logger.py
+++ b/benchmarl/experiment/logger.py
@@ -164,12 +164,8 @@ class Logger:
         max_length_rollout_0 = 0
         for i in range(len(rollouts)):
             r = rollouts[i]
-            next_done = self._get_global_done(r)
-            # Reduce it to batch size
-            next_done = next_done.sum(
-                tuple(range(r.batch_dims, next_done.ndim)),
-                dtype=torch.bool,
-            )
+            next_done = self._get_global_done(r).squeeze(-1)
+
             # First done index for this traj
             done_index = next_done.nonzero(as_tuple=True)[0]
             if done_index.numel() > 0:

--- a/benchmarl/experiment/logger.py
+++ b/benchmarl/experiment/logger.py
@@ -104,7 +104,12 @@ class Logger:
             )
         for group in self.group_map.keys():
             group_episode_rewards = self._log_individual_and_group_rewards(
-                group, batch, gobal_done, any_episode_ended, to_log
+                group,
+                batch,
+                gobal_done,
+                any_episode_ended,
+                to_log,
+                log_individual_agents=False,  # Turn on if you want single agent granularity
             )
             # group_episode_rewards has shape (n_episodes) as we took the mean over agents in the group
             groups_episode_rewards.append(group_episode_rewards)


### PR DESCRIPTION
## This PR fixes the way episode rewards are computed in BenchMARL

Here is an overview:

![epispde_reward compuation](https://github.com/user-attachments/assets/1b07d48d-e385-43fb-be2c-c94e42cc21fa)

BenchMARL will be looking at the global `done` (always assumed to be set), which can usually be computed using `any` or `all` over the single agents dones.

In all cases the global done is what is used to compute the episode reward.

We log `episode_reward` min, mean, max over episodes at three different levels:
- agent (disabled by default, can be turned on manually)
- group averaged over agents in group
- global averaged over agents in groups and gropus

## Requiremment

When agents are done and the global done is not set, agents should be getting a **reward of 0** (if you are not using global rewards)

Fixes #135