### PR TITLE
[Feature] Disk storage for replay buffers

### DIFF
--- a/benchmarl/algorithms/common.py
+++ b/benchmarl/algorithms/common.py
@@ -150,7 +150,6 @@ class Algorithm(ABC):
 
         Args:
             group (str): agent group of the loss and updater
-            physical_storage (PhysicalStorage): Storage device used for saving trajectories from the replay buffer
             transforms (optional, list of Transform): Transforms to apply to the replay buffer ``.sample()`` call
 
         Returns: ReplayBuffer the group

--- a/benchmarl/algorithms/common.py
+++ b/benchmarl/algorithms/common.py
@@ -3,7 +3,7 @@
 #  This source code is licensed under the license found in the
 #  LICENSE file in the root directory of this source tree.
 #
-import os
+
 import uuid
 import pathlib
 from abc import ABC, abstractmethod

--- a/benchmarl/algorithms/common.py
+++ b/benchmarl/algorithms/common.py
@@ -3,12 +3,12 @@
 #  This source code is licensed under the license found in the
 #  LICENSE file in the root directory of this source tree.
 #
-
+import os
+import uuid
 import pathlib
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-import tempfile
 from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, Type
 
 from tensordict import TensorDictBase
@@ -74,7 +74,6 @@ class Algorithm(ABC):
         self._losses_and_updaters = {}
         self._policies_for_loss = {}
         self._policies_for_collection = {}
-        self._memmap_dir = None
 
         self._check_specs()
 
@@ -151,11 +150,10 @@ class Algorithm(ABC):
                 device=self.device if self.on_policy else self.buffer_device,
             )
         else:
-            self._memmap_dir = tempfile.TemporaryDirectory()
             storage = LazyMemmapStorage(
                 memory_size,
                 device=self.device if self.on_policy else self.buffer_device,
-                scratch_dir=self._memmap_dir.name
+                scratch_dir=f".memmap-{uuid.uuid4().hex}",
             )
 
         return storage
@@ -358,10 +356,6 @@ class Algorithm(ABC):
         Returns: the processed loss_vals
         """
         return loss_vals
-
-    def __del__(self) -> None:
-        if self._memmap_dir is not None:
-            self._memmap_dir.cleanup()
 
 
 @dataclass

--- a/benchmarl/benchmark/benchmark.py
+++ b/benchmarl/benchmark/benchmark.py
@@ -10,7 +10,6 @@ from benchmarl.algorithms.common import AlgorithmConfig
 from benchmarl.environments import Task
 from benchmarl.experiment import Experiment, ExperimentConfig
 from benchmarl.models.common import ModelConfig
-from benchmarl.algorithms.common import PhysicalStorage
 
 
 class Benchmark:
@@ -36,7 +35,6 @@ class Benchmark:
         seeds: Set[int],
         experiment_config: ExperimentConfig,
         critic_model_config: Optional[ModelConfig] = None,
-        replay_buffer_storage: Optional[PhysicalStorage] = None,
     ):
         self.algorithm_configs = algorithm_configs
         self.tasks = tasks
@@ -47,11 +45,6 @@ class Benchmark:
             critic_model_config if critic_model_config is not None else model_config
         )
         self.experiment_config = experiment_config
-        self.replay_buffer_storage = (
-            replay_buffer_storage
-            if replay_buffer_storage is not None
-            else PhysicalStorage.MEMORY
-        )
 
         print(f"Created benchmark with {self.n_experiments} experiments.")
 
@@ -72,7 +65,6 @@ class Benchmark:
                         model_config=self.model_config,
                         critic_model_config=self.critic_model_config,
                         config=self.experiment_config,
-                        replay_buffer_storage=self.replay_buffer_storage,
                     )
 
     def run_sequential(self):

--- a/benchmarl/benchmark/benchmark.py
+++ b/benchmarl/benchmark/benchmark.py
@@ -10,6 +10,7 @@ from benchmarl.algorithms.common import AlgorithmConfig
 from benchmarl.environments import Task
 from benchmarl.experiment import Experiment, ExperimentConfig
 from benchmarl.models.common import ModelConfig
+from benchmarl.algorithms.common import PhysicalStorage
 
 
 class Benchmark:
@@ -35,6 +36,7 @@ class Benchmark:
         seeds: Set[int],
         experiment_config: ExperimentConfig,
         critic_model_config: Optional[ModelConfig] = None,
+        replay_buffer_storage: Optional[PhysicalStorage] = None,
     ):
         self.algorithm_configs = algorithm_configs
         self.tasks = tasks
@@ -45,6 +47,11 @@ class Benchmark:
             critic_model_config if critic_model_config is not None else model_config
         )
         self.experiment_config = experiment_config
+        self.replay_buffer_storage = (
+            replay_buffer_storage
+            if replay_buffer_storage is not None
+            else PhysicalStorage.MEMORY
+        )
 
         print(f"Created benchmark with {self.n_experiments} experiments.")
 
@@ -65,6 +72,7 @@ class Benchmark:
                         model_config=self.model_config,
                         critic_model_config=self.critic_model_config,
                         config=self.experiment_config,
+                        replay_buffer_storage=self.replay_buffer_storage,
                     )
 
     def run_sequential(self):

--- a/benchmarl/conf/experiment/base_experiment.yaml
+++ b/benchmarl/conf/experiment/base_experiment.yaml
@@ -49,7 +49,7 @@ exploration_anneal_frames: null
 # The maximum number of experiment iterations before the experiment terminates, exclusive with max_n_frames
 max_n_iters: null
 # Number of collected frames before ending, exclusive with max_n_iters
-max_n_frames: 18_000
+max_n_frames: 3_000_000
 
 # Number of frames collected and each experiment iteration
 on_policy_collected_frames_per_batch: 6000
@@ -115,9 +115,9 @@ restore_file: null
 restore_map_location: null
 # Interval for experiment saving in terms of collected frames (this should be a multiple of on/off_policy_collected_frames_per_batch).
 # Set it to 0 to disable checkpointing
-checkpoint_interval: 6000
+checkpoint_interval: 0
 # Whether to checkpoint when the experiment is done
-checkpoint_at_end: True
+checkpoint_at_end: False
 # How many checkpoints to keep. As new checkpoints are taken, temporally older checkpoints are deleted to keep this number of
 # checkpoints. The checkpoint at the end is included in this number. Set to `null` to keep all checkpoints.
 keep_checkpoints_num: 3

--- a/benchmarl/conf/experiment/base_experiment.yaml
+++ b/benchmarl/conf/experiment/base_experiment.yaml
@@ -6,7 +6,8 @@ defaults:
 sampling_device: "cpu"
 # The device for training (e.g. cuda)
 train_device: "cpu"
-# The device for the replay buffer of off-policy algorithms (e.g. cuda)
+# The device for the replay buffer of off-policy algorithms (e.g. cuda).
+# Use "disk" to store it on disk (in the experiment save_folder)
 buffer_device: "cpu"
 
 # Whether to share the parameters of the policy within agent groups
@@ -48,7 +49,7 @@ exploration_anneal_frames: null
 # The maximum number of experiment iterations before the experiment terminates, exclusive with max_n_frames
 max_n_iters: null
 # Number of collected frames before ending, exclusive with max_n_iters
-max_n_frames: 3_000_000
+max_n_frames: 18_000
 
 # Number of frames collected and each experiment iteration
 on_policy_collected_frames_per_batch: 6000
@@ -114,9 +115,9 @@ restore_file: null
 restore_map_location: null
 # Interval for experiment saving in terms of collected frames (this should be a multiple of on/off_policy_collected_frames_per_batch).
 # Set it to 0 to disable checkpointing
-checkpoint_interval: 0
+checkpoint_interval: 6000
 # Whether to checkpoint when the experiment is done
-checkpoint_at_end: False
+checkpoint_at_end: True
 # How many checkpoints to keep. As new checkpoints are taken, temporally older checkpoints are deleted to keep this number of
 # checkpoints. The checkpoint at the end is included in this number. Set to `null` to keep all checkpoints.
 keep_checkpoints_num: 3

--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -312,7 +312,6 @@ class Experiment(CallbackNotifier):
             If None, it defaults to model_config
         callbacks (list of Callback, optional): callbacks for this experiment
     """
-
     def __init__(
         self,
         task: Task,

--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -8,8 +8,9 @@ from __future__ import annotations
 
 import copy
 import importlib
-
 import os
+import shutil
+
 import time
 from collections import deque, OrderedDict
 from dataclasses import dataclass, MISSING
@@ -21,6 +22,7 @@ import torch
 from tensordict import TensorDictBase
 from tensordict.nn import TensorDictSequential
 from torchrl.collectors import SyncDataCollector
+from torchrl.data import LazyMemmapStorage
 
 from torchrl.envs import ParallelEnv, SerialEnv, TransformedEnv
 from torchrl.envs.transforms import Compose
@@ -769,6 +771,10 @@ class Experiment(CallbackNotifier):
             self.rollout_env.close()
         self.test_env.close()
         self.logger.finish()
+
+        for group in self.replay_buffers:
+            if isinstance(self.replay_buffers[group].storage, LazyMemmapStorage):
+                shutil.rmtree(self.replay_buffers[group].storage.scratch_dir, ignore_errors=True)
 
     def _get_excluded_keys(self, group: str):
         excluded_keys = []


### PR DESCRIPTION
This is an idea of how to add an option to use disk storage for the replay buffer. It is not advisable to rely on temporary paths for this purpose, as some operating systems impose limitations on their storage capacity.

fixes #154