### PR TITLE
[Feature] Enable `Mlp` to work with multi-dimensional features

### DIFF
--- a/benchmarl/conf/model/layers/mlp.yaml
+++ b/benchmarl/conf/model/layers/mlp.yaml
@@ -9,3 +9,5 @@ activation_kwargs: null
 
 norm_class: null
 norm_kwargs: null
+
+num_feature_dims: 1

--- a/benchmarl/models/mlp.py
+++ b/benchmarl/models/mlp.py
@@ -29,6 +29,7 @@ class Mlp(Model):
         activation_kwargs (dict, optional): kwargs to be used with the activation class;
         norm_class (Type, optional): normalization class, if any.
         norm_kwargs (dict, optional): kwargs to be used with the normalization layers;
+        num_feature_dims: number of dimensions to be considered as features.
 
     """
 
@@ -36,6 +37,7 @@ class Mlp(Model):
         self,
         **kwargs,
     ):
+        self.num_feature_dims = kwargs.pop("num_feature_dims", 1)
         super().__init__(
             input_spec=kwargs.pop("input_spec"),
             output_spec=kwargs.pop("output_spec"),
@@ -51,7 +53,10 @@ class Mlp(Model):
         )
 
         self.input_features = sum(
-            [spec.shape[-1] for spec in self.input_spec.values(True, True)]
+            [
+                torch.prod(torch.tensor(spec.shape[-self.num_feature_dims :])).item()
+                for spec in self.input_spec.values(True, True)
+            ]
         )
         self.output_features = self.output_leaf_spec.shape[-1]
 
@@ -83,19 +88,23 @@ class Mlp(Model):
 
         input_shape = None
         for input_key, input_spec in self.input_spec.items(True, True):
-            if (self.input_has_agent_dim and len(input_spec.shape) == 2) or (
-                not self.input_has_agent_dim and len(input_spec.shape) == 1
+            if (
+                self.input_has_agent_dim
+                and len(input_spec.shape) == self.num_feature_dims + 1
+            ) or (
+                not self.input_has_agent_dim
+                and len(input_spec.shape) == self.num_feature_dims
             ):
                 if input_shape is None:
-                    input_shape = input_spec.shape[:-1]
+                    input_shape = input_spec.shape[: -self.num_feature_dims]
                 else:
-                    if input_spec.shape[:-1] != input_shape:
+                    if input_spec.shape[: -self.num_feature_dims] != input_shape:
                         raise ValueError(
-                            f"MLP inputs should all have the same shape up to the last dimension, got {self.input_spec}"
+                            f"MLP inputs should all have the same shape up to the last {self.num_feature_dims} dimensions, got {self.input_spec}"
                         )
             else:
                 raise ValueError(
-                    f"MLP input value {input_key} from {self.input_spec} has an invalid shape, maybe you need a CNN?"
+                    f"MLP input value {input_key} from {self.input_spec} has an invalid shape, maybe you need a CNN or more feature dimensions?"
                 )
         if self.input_has_agent_dim:
             if input_shape[-1] != self.n_agents:
@@ -114,7 +123,12 @@ class Mlp(Model):
 
     def _forward(self, tensordict: TensorDictBase) -> TensorDictBase:
         # Gather in_key
-        input = torch.cat([tensordict.get(in_key) for in_key in self.in_keys], dim=-1)
+        full_input = torch.cat(
+            [tensordict.get(in_key) for in_key in self.in_keys], dim=-1
+        )
+        input = torch.flatten(
+            full_input, start_dim=-self.num_feature_dims
+        )  # flatten the last self.num_feature_dims dimensions
 
         # Has multi-agent input dimension
         if self.input_has_agent_dim:
@@ -151,6 +165,8 @@ class MlpConfig(ModelConfig):
 
     norm_class: Type[nn.Module] = None
     norm_kwargs: Optional[dict] = None
+
+    num_feature_dims: int = 1
 
     @staticmethod
     def associated_class():

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -449,3 +449,69 @@ class TestDeepsets:
         input_td = input_spec.expand(batch_size).rand()
         out_td = model(input_td)
         assert output_spec.expand(batch_size).is_in(out_td)
+
+
+class TestMlp:
+    @pytest.mark.parametrize("share_params", [True, False])
+    @pytest.mark.parametrize("batch_size", [(), (2,), (3, 2)])
+    @pytest.mark.parametrize("in_features", [[4], [2, 4], [2, 2, 1]])
+    def test_mlp_num_feature_dims(
+        self,
+        share_params,
+        batch_size,
+        in_features,
+        centralised=True,
+        input_has_agent_dim=True,
+        model_name="mlp",
+        n_agents=3,
+        out_features=2,
+    ):
+
+        torch.manual_seed(0)
+
+        config = model_config_registry[model_name].get_from_yaml()
+        config.num_feature_dims = len(in_features)
+
+        multi_agent_input_shape = (n_agents, *in_features)
+        other_multi_agent_input_shape = (n_agents, *in_features)
+
+        input_spec = Composite(
+            {
+                "agents": Composite(
+                    {
+                        "observation": Unbounded(shape=multi_agent_input_shape),
+                        "other": Unbounded(shape=other_multi_agent_input_shape),
+                    },
+                    shape=(n_agents,),
+                )
+            }
+        )
+
+        if output_has_agent_dim(centralised=centralised, share_params=share_params):
+            output_spec = Composite(
+                {
+                    "agents": Composite(
+                        {"out": Unbounded(shape=(n_agents, out_features))},
+                        shape=(n_agents,),
+                    )
+                },
+            )
+        else:
+            output_spec = Composite(
+                {"out": Unbounded(shape=(out_features,))},
+            )
+
+        model = config.get_model(
+            input_spec=input_spec,
+            output_spec=output_spec,
+            share_params=share_params,
+            centralised=centralised,
+            input_has_agent_dim=input_has_agent_dim,
+            n_agents=n_agents,
+            device="cpu",
+            agent_group="agents",
+            action_spec=None,
+        )
+        input_td = input_spec.expand(batch_size).rand()
+        out_td = model(input_td)
+        assert output_spec.expand(batch_size).is_in(out_td)


### PR DESCRIPTION
## What does this PR do?

It adds support to inputs with multi-dimensional features for the `Mlp` model. It works by simply adding an optional parameter `num_feature_dims` to specify the number of dimensions to be considered as features, and flattening them in the forward pass.