### PR TITLE
[Feature] Create `wandb` config at init for offline support

### DIFF
--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -611,6 +611,21 @@ class Experiment(CallbackNotifier):
             pickle.dump(self.callbacks, f)
 
     def _setup_logger(self):
+        hparams_kwargs = {
+            "critic_model_name": self.critic_model_name,
+            "experiment_config": self.config.__dict__,
+            "algorithm_config": self.algorithm_config.__dict__,
+            "model_config": self.model_config.__dict__,
+            "critic_model_config": self.critic_model_config.__dict__,
+            "task_config": self.task.config,
+            "continuous_actions": self.continuous_actions,
+            "on_policy": self.on_policy,
+            "algorithm_name": self.algorithm_name,
+            "model_name": self.model_name,
+            "task_name": self.task_name,
+            "environment_name": self.environment_name,
+            "seed": self.seed,
+        }
         self.logger = Logger(
             experiment_name=self.name,
             folder_name=str(self.folder_name),
@@ -622,18 +637,12 @@ class Experiment(CallbackNotifier):
             group_map=self.group_map,
             seed=self.seed,
             project_name=self.config.project_name,
-            wandb_extra_kwargs=self.config.wandb_extra_kwargs,
+            wandb_extra_kwargs={
+                **self.config.wandb_extra_kwargs,
+                "config": hparams_kwargs,
+            },
         )
-        self.logger.log_hparams(
-            critic_model_name=self.critic_model_name,
-            experiment_config=self.config.__dict__,
-            algorithm_config=self.algorithm_config.__dict__,
-            model_config=self.model_config.__dict__,
-            critic_model_config=self.critic_model_config.__dict__,
-            task_config=self.task.config,
-            continuous_actions=self.continuous_actions,
-            on_policy=self.on_policy,
-        )
+        self.logger.log_hparams(**hparams_kwargs)
 
     def run(self):
         """Run the experiment until completion."""

--- a/benchmarl/experiment/logger.py
+++ b/benchmarl/experiment/logger.py
@@ -83,15 +83,6 @@ class Logger:
             )
 
     def log_hparams(self, **kwargs):
-        kwargs.update(
-            {
-                "algorithm_name": self.algorithm_name,
-                "model_name": self.model_name,
-                "task_name": self.task_name,
-                "environment_name": self.environment_name,
-                "seed": self.seed,
-            }
-        )
         for logger in self.loggers:
             if isinstance(logger, TensorboardLogger):
                 # Tensorboard does not like nested dictionaries -> flatten them


### PR DESCRIPTION
Unfortunately, `wandb` has an issue with updating the config during a run while offline, it only logs the initial config, cf wandb/wandb#6974.

The easiest solution might be to build `hparams` before the logger initialisation, which can be provided as a config for wandb and later to the logger in `log_hparams`.