### PR TITLE
[Feature] Learning rate scheduling callback from yaml

### DIFF
--- a/benchmarl/__init__.py
+++ b/benchmarl/__init__.py
@@ -23,6 +23,7 @@ if _has_hydra:
         from hydra.core.config_store import ConfigStore
 
         from benchmarl.algorithms import algorithm_config_registry
+        from benchmarl.callbacks import callback_config_registry
         from benchmarl.environments import _task_class_registry
         from benchmarl.experiment import ExperimentConfig
 
@@ -33,6 +34,11 @@ if _has_hydra:
         # Load algos schemas
         for algo_name, algo_schema in algorithm_config_registry.items():
             cs.store(name=f"{algo_name}_config", group="algorithm", node=algo_schema)
+        # Load callback schemas
+        for callback_name, callback_schema in callback_config_registry.items():
+            cs.store(
+                name=f"{callback_name}_config", group="callback", node=callback_schema
+            )
         # Load task schemas
         for task_schema_name, task_schema in _task_class_registry.items():
             cs.store(name=f"{task_schema_name}_config", group="task", node=task_schema)

--- a/benchmarl/callbacks/__init__.py
+++ b/benchmarl/callbacks/__init__.py
@@ -1,0 +1,24 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  This source code is licensed under the license found in the
+#  LICENSE file in the root directory of this source tree.
+#
+
+from .common import CallbackConfig
+from .lr_scheduler import LRSchedulerCallback, LRSchedulerConfig
+from .parameter_scheduler import ParameterSchedulerCallback, ParameterSchedulerConfig
+from .scheduler import Scheduler, SchedulerConfig
+from .task_parameter_scheduler import (
+    TaskParameterSchedulerCallback,
+    TaskParameterSchedulerConfig,
+)
+
+__all__ = [
+    "CallbackConfig",
+    "LRSchedulerCallback",
+    "LRSchedulerConfig",
+]
+
+callback_config_registry = {
+    "lr_scheduler": LRSchedulerConfig,
+}

--- a/benchmarl/callbacks/__init__.py
+++ b/benchmarl/callbacks/__init__.py
@@ -6,12 +6,6 @@
 
 from .common import CallbackConfig
 from .lr_scheduler import LRSchedulerCallback, LRSchedulerConfig
-from .parameter_scheduler import ParameterSchedulerCallback, ParameterSchedulerConfig
-from .scheduler import Scheduler, SchedulerConfig
-from .task_parameter_scheduler import (
-    TaskParameterSchedulerCallback,
-    TaskParameterSchedulerConfig,
-)
 
 __all__ = [
     "CallbackConfig",

--- a/benchmarl/callbacks/common.py
+++ b/benchmarl/callbacks/common.py
@@ -1,0 +1,78 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  This source code is licensed under the license found in the
+#  LICENSE file in the root directory of this source tree.
+#
+
+import pathlib
+
+from abc import abstractmethod
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Type
+
+from benchmarl.experiment import Callback
+from benchmarl.utils import _read_yaml_config
+
+
+@dataclass
+class CallbackConfig:
+    """
+    Dataclass representing a callback configuration.
+    This should be overridden by implemented callbacks.
+    Implementors should:
+
+        1. add configuration parameters for their callback
+        2. implement all abstract methods
+
+    """
+
+    def get_callback(self) -> Callback:
+        """
+        Main function to turn the config into the associated callback
+
+        Returns: the Callback
+
+        """
+        return self.associated_class()(
+            **self.__dict__,  # Passes all the custom config parameters
+        )
+
+    @staticmethod
+    def _load_from_yaml(name: str) -> Dict[str, Any]:
+        yaml_path = (
+            pathlib.Path(__file__).parent.parent
+            / "conf"
+            / "callbacks"
+            / f"{name.lower()}.yaml"
+        )
+        return _read_yaml_config(str(yaml_path.resolve()))
+
+    @classmethod
+    def get_from_yaml(cls, path: Optional[str] = None):
+        """
+        Load the callback configuration from yaml
+
+        Args:
+            path (str, optional): The full path of the yaml file to load from.
+                If None, it will default to
+                ``benchmarl/conf/callbacks/self.associated_class().__name__``
+
+        Returns: the loaded CallbackConfig
+        """
+
+        if path is None:
+            config = CallbackConfig._load_from_yaml(
+                name=cls.associated_class().__name__
+            )
+
+        else:
+            config = _read_yaml_config(path)
+        return cls(**config)
+
+    @staticmethod
+    @abstractmethod
+    def associated_class() -> Type[Callback]:
+        """
+        The callback class associated to the config
+        """
+        raise NotImplementedError

--- a/benchmarl/callbacks/lr_scheduler.py
+++ b/benchmarl/callbacks/lr_scheduler.py
@@ -1,0 +1,79 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  This source code is licensed under the MIT license found in the
+#  LICENSE file in the root directory of this source tree.
+#
+
+from dataclasses import dataclass, MISSING
+from typing import Any, Dict
+
+from benchmarl.callbacks.common import CallbackConfig
+from benchmarl.experiment.callback import Callback
+from benchmarl.utils import _class_from_name
+
+
+@dataclass
+class LRSchedulerConfig(CallbackConfig):
+    """Configuration for the LR Scheduler Callback."""
+
+    scheduler_class: str = MISSING  # "torch.optim.lr_scheduler.StepLR"
+    scheduler_params: Dict[str, Any] = MISSING
+    log_lr: bool = MISSING
+
+    @staticmethod
+    def associated_class():
+        return LRSchedulerCallback
+
+
+class LRSchedulerCallback(Callback):
+    """
+    Callback that applies learning rate scheduling to a single optimizer.
+
+    Uses PyTorch's built-in schedulers.
+    """
+
+    def __init__(
+        self,
+        scheduler_class: str,
+        scheduler_params: Dict[str, Any],
+        log_lr: bool = True,
+    ):
+        super().__init__()
+        self.scheduler_class = scheduler_class
+        self.scheduler_params = scheduler_params
+        self.log_lr = log_lr
+
+        self.schedulers = None
+
+    def on_setup(self):
+        """Setup the scheduler after the experiment is initialized."""
+
+        scheduler_class = _class_from_name(self.scheduler_class)
+        kwargs = {
+            k: v
+            for k, v in self.scheduler_params.items()
+            if k in scheduler_class.__init__.__code__.co_varnames
+        }
+
+        self.schedulers = []
+        for optimizer_group in self.experiment.optimizers.values():
+            for optimizer in optimizer_group.values():
+                scheduler = scheduler_class(optimizer, **kwargs)
+                self.schedulers.append(scheduler)
+
+        if len(self.schedulers) == 0:
+            raise ValueError("No optimizer found in the experiment")
+
+    def on_train_step(self, batch, group: str):
+        """Step the scheduler during training."""
+        for scheduler in self.schedulers:
+            scheduler.step()
+
+        if self.log_lr:
+            lr = self.schedulers[0].get_last_lr()[0]
+            to_log = {
+                f"train/{group}/lr": lr for group in self.experiment.group_map.keys()
+            }
+            self.experiment.logger.log(to_log, step=self.experiment.n_iters_performed)
+
+        return None

--- a/benchmarl/conf/callback/lr_scheduler.yaml
+++ b/benchmarl/conf/callback/lr_scheduler.yaml
@@ -1,0 +1,12 @@
+defaults:
+  - lr_scheduler_config
+  - _self_
+
+# Scheduler to use (e.g., "StepLR", "CosineAnnealingLR", "ExponentialLR")
+scheduler_class: torch.optim.lr_scheduler.StepLR
+
+scheduler_params:
+  step_size: 1000  # For StepLR: step size for learning rate decay
+  gamma: 0.9       # For StepLR: multiplicative factor for learning rate decay
+
+log_lr: true

--- a/benchmarl/conf/config.yaml
+++ b/benchmarl/conf/config.yaml
@@ -4,6 +4,7 @@ defaults:
   - task: ???
   - model: layers/mlp
   - model@critic_model: layers/mlp
+  - callback@callbacks.c1: lr_scheduler
   - _self_
 
 seed: 0

--- a/benchmarl/experiment/callback.py
+++ b/benchmarl/experiment/callback.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Any, Dict, List
 
 from tensordict import TensorDictBase
 
@@ -26,6 +26,10 @@ class Callback:
 
     def on_setup(self):
         """A callback called atexperiment setup."""
+        pass
+
+    def on_load_state_dict(self, state_dict: Dict[str, Any]):
+        """A callback called at state_dict load."""
         pass
 
     def on_batch_collected(self, batch: TensorDictBase):
@@ -73,6 +77,10 @@ class Callback:
         """
         pass
 
+    def on_state_dict(self, state_dict: Dict[str, Any]):
+        """A callback called at state_dict save."""
+        pass
+
 
 class CallbackNotifier:
     def __init__(self, experiment, callbacks: List[Callback]):
@@ -83,6 +91,10 @@ class CallbackNotifier:
     def _on_setup(self):
         for callback in self.callbacks:
             callback.on_setup()
+
+    def _on_load_state_dict(self, state_dict: Dict[str, Any]):
+        for callback in self.callbacks:
+            callback.on_load_state_dict(state_dict)
 
     def _on_batch_collected(self, batch: TensorDictBase):
         for callback in self.callbacks:
@@ -106,3 +118,7 @@ class CallbackNotifier:
     def _on_evaluation_end(self, rollouts: List[TensorDictBase]):
         for callback in self.callbacks:
             callback.on_evaluation_end(rollouts)
+
+    def _on_state_dict(self, state_dict: Dict[str, Any]):
+        for callback in self.callbacks:
+            callback.on_state_dict(state_dict)

--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -962,6 +962,7 @@ class Experiment(CallbackNotifier):
         )
         if not self.config.collect_with_grad:
             state_dict.update({"collector": self.collector.state_dict()})
+        self._on_state_dict(state_dict)
         return state_dict
 
     def load_state_dict(self, state_dict: Dict) -> None:
@@ -983,6 +984,7 @@ class Experiment(CallbackNotifier):
         self.total_frames = state_dict["state"]["total_frames"]
         self.n_iters_performed = state_dict["state"]["n_iters_performed"]
         self.mean_return = state_dict["state"]["mean_return"]
+        self._on_load_state_dict(state_dict)
 
     def _save_experiment(self) -> None:
         """Checkpoint trainer"""

--- a/benchmarl/hydra_config.py
+++ b/benchmarl/hydra_config.py
@@ -49,7 +49,7 @@ def load_experiment_from_hydra(
     task_config = load_task_config_from_hydra(cfg.task, task_name)
     model_config = load_model_config_from_hydra(cfg.model)
     critic_model_config = load_model_config_from_hydra(cfg.critic_model)
-    _callbacks = load_callbacks_from_hydra(getattr(cfg, "callbacks", {}))
+    _callbacks = load_callbacks_from_hydra(getattr(cfg, "callbacks", None) or {})
 
     return Experiment(
         task=task_config,

--- a/benchmarl/hydra_config.py
+++ b/benchmarl/hydra_config.py
@@ -6,11 +6,12 @@
 import importlib
 from dataclasses import is_dataclass
 from pathlib import Path
+from typing import List
 
 from benchmarl.algorithms.common import AlgorithmConfig
 from benchmarl.environments import task_config_registry, TaskClass
 from benchmarl.environments.common import _type_check_task_config
-from benchmarl.experiment import Experiment, ExperimentConfig
+from benchmarl.experiment import Callback, Experiment, ExperimentConfig
 from benchmarl.models import model_config_registry
 from benchmarl.models.common import ModelConfig, parse_model_config, SequenceModelConfig
 
@@ -48,6 +49,7 @@ def load_experiment_from_hydra(
     task_config = load_task_config_from_hydra(cfg.task, task_name)
     model_config = load_model_config_from_hydra(cfg.model)
     critic_model_config = load_model_config_from_hydra(cfg.critic_model)
+    _callbacks = load_callbacks_from_hydra(getattr(cfg, "callbacks", {}))
 
     return Experiment(
         task=task_config,
@@ -56,7 +58,7 @@ def load_experiment_from_hydra(
         critic_model_config=critic_model_config,
         seed=cfg.seed,
         config=experiment_config,
-        callbacks=callbacks,
+        callbacks=_callbacks + [*callbacks],
     )
 
 
@@ -132,6 +134,16 @@ def load_model_config_from_hydra(cfg: DictConfig) -> ModelConfig:
                 OmegaConf.to_container(cfg, resolve=True, throw_on_missing=True)
             )
         )
+
+
+def load_callbacks_from_hydra(cfg: DictConfig) -> List[Callback]:
+    """Returns a list of :class:`~benchmarl.callbacks.Callback` from hydra config.
+
+    Args:
+        cfg (DictConfig): the callbacks config dictionary from hydra
+
+    """
+    return [OmegaConf.to_object(callback).get_callback() for callback in cfg.values()]
 
 
 def _find_hydra_folder(restore_file: str) -> str:

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -29,6 +29,20 @@ def test_loading_callbacks(callback_name):
         )
 
 
+def test_disabling_callbacks():
+    with initialize(version_base=None, config_path="../benchmarl/conf"):
+        cfg = compose(
+            config_name="config",
+            overrides=[
+                "algorithm=mappo",
+                "task=vmas/balance",
+                "callbacks=null",
+            ],
+        )
+        callbacks = load_callbacks_from_hydra(getattr(cfg, "callbacks", None) or {})
+        assert len(callbacks) == 0
+
+
 class TestLRSchedulerCallback:
     callback_params_override = {
         "StepLR": [

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -32,7 +32,7 @@ def test_loading_callbacks(callback_name):
 class TestLRSchedulerCallback:
     callback_params_override = {
         "StepLR": [
-            "scheduler_params={step_size: 100, gamma: 0.9}",
+            "scheduler_params={step_size: 2, gamma: 0.9}",
         ],
         "CosineAnnealingLR": [
             "scheduler_params={T_max: 1000}",

--- a/test/test_callbacks.py
+++ b/test/test_callbacks.py
@@ -1,0 +1,66 @@
+#  Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+#  This source code is licensed under the license found in the
+#  LICENSE file in the root directory of this source tree.
+#
+
+import pytest
+
+from benchmarl.callbacks import callback_config_registry, LRSchedulerCallback
+from benchmarl.hydra_config import load_callbacks_from_hydra
+
+from hydra import compose, initialize
+
+
+@pytest.mark.parametrize("callback_name", callback_config_registry.keys())
+def test_loading_callbacks(callback_name):
+    with initialize(version_base=None, config_path="../benchmarl/conf"):
+        cfg = compose(
+            config_name="config",
+            overrides=[
+                "algorithm=mappo",
+                "task=vmas/balance",
+                f"callback@callbacks.c1={callback_name}",
+            ],
+        )
+        callback = load_callbacks_from_hydra(cfg.callbacks)[0]
+        assert isinstance(
+            callback, callback_config_registry[callback_name].associated_class()
+        )
+
+
+class TestLRSchedulerCallback:
+    callback_params_override = {
+        "StepLR": [
+            "scheduler_params={step_size: 100, gamma: 0.9}",
+        ],
+        "CosineAnnealingLR": [
+            "scheduler_params={T_max: 1000}",
+        ],
+        "ExponentialLR": [
+            "scheduler_params={gamma: 0.95}",
+        ],
+    }
+
+    @pytest.mark.parametrize("scheduler_type", callback_params_override.keys())
+    @pytest.mark.parametrize("target_optimizer", ["loss_objective", "loss_critic"])
+    @pytest.mark.parametrize("log_lr", [True, False])
+    def test_lr_scheduler(self, scheduler_type, target_optimizer, log_lr):
+        """Test LR scheduler configuration creation with different parameters."""
+        with initialize(version_base=None, config_path="../benchmarl/conf"):
+            cfg = compose(
+                config_name="config",
+                overrides=[
+                    "algorithm=mappo",
+                    "task=vmas/balance",
+                    "callback@callbacks.c1=lr_scheduler",
+                    f"callbacks.c1.scheduler_class=torch.optim.lr_scheduler.{scheduler_type}",
+                    *[
+                        f"++callbacks.c1.{override}"
+                        for override in self.callback_params_override[scheduler_type]
+                    ],
+                    f"callbacks.c1.log_lr={log_lr}",
+                ],
+            )
+            callback = load_callbacks_from_hydra(cfg.callbacks)[0]
+            assert isinstance(callback, LRSchedulerCallback)

--- a/test/utils_experiment.py
+++ b/test/utils_experiment.py
@@ -4,11 +4,9 @@
 #  LICENSE file in the root directory of this source tree.
 #
 
-from typing import List, Optional
-
 from benchmarl.algorithms.common import AlgorithmConfig
 from benchmarl.environments import Task
-from benchmarl.experiment import Callback, Experiment, ExperimentConfig
+from benchmarl.experiment import Experiment, ExperimentConfig
 from benchmarl.models.common import ModelConfig
 
 
@@ -19,7 +17,6 @@ class ExperimentUtils:
         task: Task,
         experiment_config: ExperimentConfig,
         model_config: ModelConfig,
-        callbacks: Optional[List[Callback]] = None,
     ):
         max_n_iters = experiment_config.max_n_iters
         experiment = Experiment(
@@ -28,7 +25,6 @@ class ExperimentUtils:
             seed=0,
             config=experiment_config,
             task=task,
-            callbacks=callbacks,
         )
         experiment.run()
 
@@ -47,7 +43,6 @@ class ExperimentUtils:
             seed=0,
             config=experiment_config,
             task=task,
-            callbacks=callbacks,
         )
         for param1, param2 in zip(
             list(experiment.policy.parameters()), list(policy.parameters())

--- a/test/utils_experiment.py
+++ b/test/utils_experiment.py
@@ -4,9 +4,11 @@
 #  LICENSE file in the root directory of this source tree.
 #
 
+from typing import List, Optional
+
 from benchmarl.algorithms.common import AlgorithmConfig
 from benchmarl.environments import Task
-from benchmarl.experiment import Experiment, ExperimentConfig
+from benchmarl.experiment import Callback, Experiment, ExperimentConfig
 from benchmarl.models.common import ModelConfig
 
 
@@ -17,6 +19,7 @@ class ExperimentUtils:
         task: Task,
         experiment_config: ExperimentConfig,
         model_config: ModelConfig,
+        callbacks: Optional[List[Callback]] = None,
     ):
         max_n_iters = experiment_config.max_n_iters
         experiment = Experiment(
@@ -25,6 +28,7 @@ class ExperimentUtils:
             seed=0,
             config=experiment_config,
             task=task,
+            callbacks=callbacks,
         )
         experiment.run()
 
@@ -43,6 +47,7 @@ class ExperimentUtils:
             seed=0,
             config=experiment_config,
             task=task,
+            callbacks=callbacks,
         )
         for param1, param2 in zip(
             list(experiment.policy.parameters()), list(policy.parameters())


### PR DESCRIPTION
## What does this PR do?

It implements a callback `LRSchedulerCallback` to use `torch` scheduling classes. For further extension, this callback is integrated within the config group `callback`. The `Callback` & `CallbackNotifier` classes were extended to enable callbacks to save data in the state dict (e.g. learning rate schedulers).

It can be loaded using:

```yaml
defaults:
  ...
  - callback@callbacks.c1: lr_scheduler
  - _self_
```

Depending on the class, additional arguments can be provided:

```yaml
callbacks:
  c1:
    scheduler_class: torch.optim.lr_scheduler.CosineAnnealingLR
    scheduler_params:
      T_max: 500
      eta_min: 0.0
```

It can also be disabled:

```yaml
defaults:
  ...
  - callback@callbacks: null
  - _self_
```

or left empty:

```yaml
defaults:
  ...
  - _self_
```

## To discuss

Maybe the defaults should be without any callback (can be left empty), yet the current LR scheduling doesn't change much training with basic configs. Maybe we should also save the optimizer within the experiment?