### PR TITLE
[BugFix] Patch save folder when reloading from checkpoint

### DIFF
--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -1035,7 +1035,7 @@ class Experiment(CallbackNotifier):
             critic_model_config = pickle.load(f)
             callbacks = pickle.load(f)
         task.config = task_config
-        experiment_config.save_folder = experiment_folder
+        experiment_config.save_folder = experiment_folder.parent
         experiment_config.restore_file = restore_file
         experiment = Experiment(
             task=task,


### PR DESCRIPTION
We need to patch the save folder when we reload the experiment from a different path (if relative).