### PR TITLE
[Feature] Enable overwriting experiment config on reload

### DIFF
--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -1038,7 +1038,6 @@ class Experiment(CallbackNotifier):
             critic_model_config = pickle.load(f)
             callbacks = pickle.load(f)
         task.config = task_config
-        experiment_config.save_folder = experiment_folder.parent
         experiment_config.restore_file = restore_file
         if experiment_patch is not None:
             for key, value in experiment_patch.items():


### PR DESCRIPTION
Enable overwriting the experiment config when reloading from a file, useful when reloaded with a different setup that requires different parameters like `restore_map_location` or `training_device`.