### PR TITLE
[Feature] Enable the exclusion of buffers in checkpoints

### DIFF
--- a/benchmarl/conf/experiment/base_experiment.yaml
+++ b/benchmarl/conf/experiment/base_experiment.yaml
@@ -130,3 +130,5 @@ checkpoint_at_end: False
 # How many checkpoints to keep. As new checkpoints are taken, temporally older checkpoints are deleted to keep this number of
 # checkpoints. The checkpoint at the end is included in this number. Set to `null` to keep all checkpoints.
 keep_checkpoints_num: 3
+# Whether to exclude the replay buffers from the checkpoint
+exclude_buffer_from_checkpoint: False

--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -121,6 +121,7 @@ class ExperimentConfig:
     checkpoint_interval: int = MISSING
     checkpoint_at_end: bool = MISSING
     keep_checkpoints_num: Optional[int] = MISSING
+    exclude_buffer_from_checkpoint: bool = MISSING
 
     def train_batch_size(self, on_policy: bool) -> int:
         """
@@ -963,7 +964,9 @@ class Experiment(CallbackNotifier):
             state=state,
             **{f"loss_{k}": item.state_dict() for k, item in self.losses.items()},
             **{
-                f"buffer_{k}": item.state_dict() if len(item) else None
+                f"buffer_{k}": item.state_dict()
+                if len(item) and not self.config.exclude_buffer_from_checkpoint
+                else None
                 for k, item in self.replay_buffers.items()
             },
         )


### PR DESCRIPTION
It would be nice to be able to opt out of saving buffers, especially since they can rapidly become huge.

Should we add proper tests about experiments saving and loading?