### PR TITLE
[Feature] New `Callback` methods for `state_dict`

### DIFF
--- a/benchmarl/experiment/callback.py
+++ b/benchmarl/experiment/callback.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import Any, Dict, List
 
 from tensordict import TensorDictBase
 
@@ -26,6 +26,10 @@ class Callback:
 
     def on_setup(self):
         """A callback called atexperiment setup."""
+        pass
+
+    def on_load_state_dict(self, state_dict: Dict[str, Any]):
+        """A callback called at state_dict load."""
         pass
 
     def on_batch_collected(self, batch: TensorDictBase):
@@ -73,6 +77,10 @@ class Callback:
         """
         pass
 
+    def on_state_dict(self, state_dict: Dict[str, Any]):
+        """A callback called at state_dict save."""
+        pass
+
 
 class CallbackNotifier:
     def __init__(self, experiment, callbacks: List[Callback]):
@@ -83,6 +91,10 @@ class CallbackNotifier:
     def _on_setup(self):
         for callback in self.callbacks:
             callback.on_setup()
+
+    def _on_load_state_dict(self, state_dict: Dict[str, Any]):
+        for callback in self.callbacks:
+            callback.on_load_state_dict(state_dict)
 
     def _on_batch_collected(self, batch: TensorDictBase):
         for callback in self.callbacks:
@@ -106,3 +118,7 @@ class CallbackNotifier:
     def _on_evaluation_end(self, rollouts: List[TensorDictBase]):
         for callback in self.callbacks:
             callback.on_evaluation_end(rollouts)
+
+    def _on_state_dict(self, state_dict: Dict[str, Any]):
+        for callback in self.callbacks:
+            callback.on_state_dict(state_dict)

--- a/benchmarl/experiment/callback.py
+++ b/benchmarl/experiment/callback.py
@@ -25,7 +25,7 @@ class Callback:
         self.experiment = None
 
     def on_setup(self):
-        """A callback called atexperiment setup."""
+        """A callback called at experiment setup."""
         pass
 
     def on_load_state_dict(self, state_dict: Dict[str, Any]):

--- a/benchmarl/experiment/experiment.py
+++ b/benchmarl/experiment/experiment.py
@@ -972,6 +972,7 @@ class Experiment(CallbackNotifier):
         )
         if not self.config.collect_with_grad:
             state_dict.update({"collector": self.collector.state_dict()})
+        self._on_state_dict(state_dict)
         return state_dict
 
     def load_state_dict(self, state_dict: Dict) -> None:
@@ -993,6 +994,7 @@ class Experiment(CallbackNotifier):
         self.total_frames = state_dict["state"]["total_frames"]
         self.n_iters_performed = state_dict["state"]["n_iters_performed"]
         self.mean_return = state_dict["state"]["mean_return"]
+        self._on_load_state_dict(state_dict)
 
     def _save_experiment(self) -> None:
         """Checkpoint trainer"""


### PR DESCRIPTION
New methods to easily manipulate `state_dict`. Potential use cases:

- Save additional training state like `lr` schedulers (exemple in #220 )
- Parse experiment `state_dict` for cross-experiment checkpoints, like in #235 and #207 